### PR TITLE
send AUTH PLAIN LOGIN in response to EHLO in event if AllowUnsecureAu…

### DIFF
--- a/Src/SmtpServer/Protocol/EhloCommand.cs
+++ b/Src/SmtpServer/Protocol/EhloCommand.cs
@@ -61,7 +61,7 @@ namespace SmtpServer.Protocol
                 yield return $"SIZE {_options.MaxMessageSize}";
             }
 
-            if (session.Text.IsSecure && _options.UserAuthenticator != null)
+            if ((session.Text.IsSecure || _options.AllowUnsecureAuthentication) && _options.UserAuthenticator != null)
             {
                 yield return "AUTH PLAIN LOGIN";
             }


### PR DESCRIPTION
Fixes the issue with authentication in unsecure connections.

send AUTH PLAIN LOGIN in response to EHLO in event if AllowUnsecureAuthentication is enabled