### PR TITLE
Change access modifier of classes to be used by test code.

### DIFF
--- a/Src/SmtpServer/IO/NetworkClient.cs
+++ b/Src/SmtpServer/IO/NetworkClient.cs
@@ -22,7 +22,7 @@ namespace SmtpServer.IO
         /// </summary>
         /// <param name="stream">The stream to return the tokens from.</param>
         /// <param name="bufferLength">The buffer length to read.</param>
-        internal NetworkClient(Stream stream, int bufferLength = 64)
+        public NetworkClient(Stream stream, int bufferLength = 64)
         {
             _stream = stream;
             _bufferLength = bufferLength;

--- a/Src/SmtpServer/SmtpServer.nuspec
+++ b/Src/SmtpServer/SmtpServer.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>EnkiSmtpServer</id>
+    <version>1.6.5-beta</version>
+    <authors>Cain</authors>
+    <owners>Cain</owners>
+    <licenseUrl>https://github.com/cosullivan/SmtpServer/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/cosullivan/SmtpServer</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Smtp Server write in C#</description>
+    <releaseNotes>Update to work with 8bit email.</releaseNotes>
+    <copyright>Copyright 2017</copyright>
+    <tags>smtp email server</tags>
+  </metadata>
+  <files>
+    <file src="bin\Debug\netstandard1.3\*.dll" target="lib\netstandard1.3" />
+    <file src="bin\Debug\net45\*.dll" target="lib\net45" />
+  </files>
+</package>

--- a/Src/SmtpServer/SmtpServerOptions.cs
+++ b/Src/SmtpServer/SmtpServerOptions.cs
@@ -9,7 +9,7 @@ using SmtpServer.Storage;
 
 namespace SmtpServer
 {
-    internal sealed class SmtpServerOptions : ISmtpServerOptions
+    public sealed class SmtpServerOptions : ISmtpServerOptions
     {
         readonly Collection<IPEndPoint> _endpoints = new Collection<IPEndPoint>();
         readonly Collection<IMailboxFilterFactory> _mailboxFilterFactories = new Collection<IMailboxFilterFactory>();

--- a/Src/SmtpServer/Text/ByteArrayTokenReader.cs
+++ b/Src/SmtpServer/Text/ByteArrayTokenReader.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace SmtpServer.Text
 {
-    internal sealed class ByteArrayTokenReader : TokenReader
+    public sealed class ByteArrayTokenReader : TokenReader
     {
         readonly IReadOnlyList<ArraySegment<byte>> _segments;
         readonly int _length;
@@ -15,7 +15,7 @@ namespace SmtpServer.Text
         /// Constructor.
         /// </summary>
         /// <param name="segments">The list of array segments to read from.</param>
-        internal ByteArrayTokenReader(IReadOnlyList<ArraySegment<byte>> segments)
+        public ByteArrayTokenReader(IReadOnlyList<ArraySegment<byte>> segments)
         {
             _segments = segments;
             _length = segments.Sum(segment => segment.Count);


### PR DESCRIPTION
When run automated build on appveyor, he pointed the follow errors of access to Class because using "internal" operator.

This PR change access operator to public.



  SmtpServer -> C:\projects\smtpserver\src\SmtpServer\bin\Release\net45\SmtpServer.dll
Program.cs(50,13): warning CS0162: Unreachable code detected [C:\projects\smtpserver\src\SampleApp\SampleApp.csproj]
  SampleApp -> C:\projects\smtpserver\src\SampleApp\bin\Release\SampleApp.exe
  SmtpServer -> C:\projects\smtpserver\src\SmtpServer\bin\Release\netstandard1.3\SmtpServer.dll
NetworkClientTests.cs(14,24): error CS1729: 'NetworkClient' does not contain a constructor that takes 2 arguments [C:\projects\smtpserver\src\SmtpServer.Tests\SmtpServer.Tests.csproj]
ByteArrayTokenReaderTests.cs(101,35): error CS0122: 'ByteArrayTokenReader' is inaccessible due to its protection level [C:\projects\smtpserver\src\SmtpServer.Tests\SmtpServer.Tests.csproj]
SmtpParserTests.cs(18,39): error CS0122: 'SmtpServerOptions' is inaccessible due to its protection level [C:\projects\smtpserver\src\SmtpServer.Tests\SmtpServer.Tests.csproj]
SmtpParserTests.cs(18,84): error CS0122: 'ByteArrayTokenReader' is inaccessible due to its protection level [C:\projects\smtpserver\src\SmtpServer.Tests\SmtpServer.Tests.csproj]
Command exited with code 1