### PR TITLE
Removed use of Environment.NewLine to support hosting in Linux

### DIFF
--- a/Src/SmtpServer/IO/INetworkClient.cs
+++ b/Src/SmtpServer/IO/INetworkClient.cs
@@ -160,7 +160,8 @@ namespace SmtpServer.IO
                 throw new ArgumentNullException(nameof(client));
             }
 
-            return client.WriteAsync(encoding.GetBytes(text + Environment.NewLine), cancellationToken);
+            var newLine = new string(new[] {(char) 13, (char) 10});
+            return client.WriteAsync(encoding.GetBytes(text + newLine), cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
I've made a small change in the way newlines are returned. I am hosting a project in Docker on Linux, where the use of `Environment.NewLine` differs from Windows.

On Unix platforms, `Environment.NewLine` will return `\n`, but on Windows it will return `\r\n`.

Because of the use of `Environment.NewLine` the response would never be accepted by the client when the server was hosted on Linux.

This PR effectively forces the return of `\r\n`, which I have tested to work correctly on both platforms.