### PR TITLE
Fail authentication instead of closing connection

### DIFF
--- a/Src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/Src/SmtpServer.Tests/SmtpServerTests.cs
@@ -87,6 +87,35 @@ namespace SmtpServer.Tests
             }
         }
 
+        [Theory]
+        [InlineData("",     ""        )]
+        [InlineData("user", ""        )]
+        [InlineData("",     "password")]
+        public void CanFailAuthenticationEmptyUserOrPassword(string user, string password)
+        {
+            // arrange
+            string actualUser = null;
+            string actualPassword = null;
+            var userAuthenticator = new DelegatingUserAuthenticator((u, p) =>
+            {
+                actualUser = u;
+                actualPassword = p;
+
+                return false;
+            });
+
+            using (CreateServer(options => options.AllowUnsecureAuthentication().UserAuthenticator(userAuthenticator)))
+            {
+                // act and assert
+                Assert.Throws<MailKit.Security.AuthenticationException>(() => MailClient.Send(user: user, password: password));
+
+                // assert
+                Assert.Equal(0, MessageStore.Messages.Count);
+                Assert.Equal(user, actualUser);
+                Assert.Equal(password, actualPassword);
+            }
+        }
+
         [Fact]
         public void CanReceiveBccInMessageTransaction()
         {

--- a/Src/SmtpServer/Protocol/AuthCommand.cs
+++ b/Src/SmtpServer/Protocol/AuthCommand.cs
@@ -157,7 +157,7 @@ namespace SmtpServer.Protocol
         {
             var text = await client.ReadLineAsync(Encoding.ASCII, cancellationToken).ReturnOnAnyThread();
 
-            return Encoding.UTF8.GetString(Convert.FromBase64String(text));
+            return Encoding.UTF8.GetString(Convert.FromBase64String(text ?? ""));
         }
 
         /// <summary>


### PR DESCRIPTION
SmtpServer fails when attempt to authenticate with empty user name or password (please see new unit tests for details).