### PR TITLE
Added support for proxy protocol

### DIFF
--- a/Src/SmtpServer/Protocol/ProxyProtocolCommand.cs
+++ b/Src/SmtpServer/Protocol/ProxyProtocolCommand.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmtpServer.Protocol
+{
+    /// <summary>
+    /// Support for proxy protocol version 1 header for use with HAProxy.
+    /// Documented at http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+    /// This should always (and only ever) be the first command seen on a new connection from HAProxy
+    /// </summary>
+    public sealed class ProxyProtocolCommand : SmtpCommand
+    {
+        public const string Command = "PROXY";
+
+        public IPEndPoint SourceEndpoint { get; }
+        public IPEndPoint DestinationEndpoint { get; }
+
+        public ProxyProtocolCommand(ISmtpServerOptions options, IPEndPoint sourceEndpoint, IPEndPoint destinationEndpoint) : base(options)
+        {
+            SourceEndpoint = sourceEndpoint;
+            DestinationEndpoint = destinationEndpoint;
+        }
+
+        internal override Task<bool> ExecuteAsync(SmtpSessionContext context, CancellationToken cancellationToken)
+        {
+            context.ProxySourceEndpoint = SourceEndpoint;
+            context.ProxyDestinationEndpoint = DestinationEndpoint;
+
+            // Do not transition smtp protocol state for these commands.
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/Src/SmtpServer/Protocol/SmtpCommandVisitor.cs
+++ b/Src/SmtpServer/Protocol/SmtpCommandVisitor.cs
@@ -46,6 +46,12 @@ namespace SmtpServer.Protocol
                 return;
             }
 
+            if (command is ProxyProtocolCommand)
+            {
+                Visit((ProxyProtocolCommand)command);
+                return;
+            }
+
             if (command is QuitCommand)
             {
                 Visit((QuitCommand)command);
@@ -108,6 +114,13 @@ namespace SmtpServer.Protocol
         /// </summary>
         /// <param name="command">The command that is being visited.</param>
         protected virtual void Visit(NoopCommand command) { }
+
+        /// <summary>
+        /// Visit an PROXY command.
+        /// </summary>
+        /// <param name="command">The command that is being visited.</param>
+        protected virtual void Visit(ProxyProtocolCommand command) { }
+
 
         /// <summary>
         /// Visit an QUIT command.

--- a/Src/SmtpServer/Protocol/SmtpStateMachine.cs
+++ b/Src/SmtpServer/Protocol/SmtpStateMachine.cs
@@ -30,6 +30,7 @@ namespace SmtpServer.Protocol
                     { NoopCommand.Command, TryMakeNoop },
                     { RsetCommand.Command, TryMakeRset },
                     { QuitCommand.Command, TryMakeQuit },
+                    { ProxyProtocolCommand.Command, TryMakeProxy },
                     { HeloCommand.Command, TryMakeHelo, c => c.NetworkClient.IsSecure ? SmtpState.WaitingForMailSecure : SmtpState.WaitingForMail },
                     { EhloCommand.Command, TryMakeEhlo, c => c.NetworkClient.IsSecure ? SmtpState.WaitingForMailSecure : SmtpState.WaitingForMail },
                 },
@@ -87,6 +88,7 @@ namespace SmtpServer.Protocol
 
             _stateTable.Initialize(SmtpState.Initialized);
         }
+        
 
         /// <summary>
         /// Called when the session has been authenticated.
@@ -253,6 +255,18 @@ namespace SmtpServer.Protocol
             return new SmtpParser(_options, tokenEnumerator).TryMakeRcpt(out command, out errorResponse);
         }
 
+        /// <summary>
+        /// Try to make a Proxy Protocol PROXY header.
+        /// </summary>
+        /// <param name="tokenEnumerator">The token enumerator to use when matching the command.</param>
+        /// <param name="command">The command that was found.</param>
+        /// <param name="errorResponse">The error response that was returned if a command could not be matched.</param>
+        /// <returns>true if a PROXY command was found, false if not.</returns>
+        private bool TryMakeProxy(TokenEnumerator tokenEnumerator, out SmtpCommand command, out SmtpResponse errorResponse)
+        {
+            return new SmtpParser(_options, tokenEnumerator).TryMakeProxy(out command, out errorResponse);
+        }
+        
         /// <summary>
         /// Try to make a DATA command.
         /// </summary>
@@ -476,4 +490,5 @@ namespace SmtpServer.Protocol
 
         #endregion
     }
+    
 }

--- a/Src/SmtpServer/SmtpSessionContext.cs
+++ b/Src/SmtpServer/SmtpSessionContext.cs
@@ -85,5 +85,15 @@ namespace SmtpServer
         /// Returns a set of propeties for the current session.
         /// </summary>
         public IDictionary<string, object> Properties { get; }
+
+        /// <summary>
+        /// The source address of the client connected to a proxy as reported by proxy-protocol.
+        /// </summary>
+        public IPEndPoint ProxySourceEndpoint { get; internal set; }
+        
+        /// <summary>
+        /// The destination endpoint on the proxy as reported by proxy-protocol.
+        /// </summary>
+        public IPEndPoint ProxyDestinationEndpoint { get; internal set; }
     }
 }

--- a/Src/SmtpServer/Tracing/TracingSmtpCommandVisitor.cs
+++ b/Src/SmtpServer/Tracing/TracingSmtpCommandVisitor.cs
@@ -81,6 +81,15 @@ namespace SmtpServer.Tracing
         }
 
         /// <summary>
+        /// Visit an PROXY command.
+        /// </summary>
+        /// <param name="command">The command that is being visited.</param>
+        protected override void Visit(ProxyProtocolCommand command)
+        {
+            _output.WriteLine($"PROXY {command.SourceEndpoint} --> {command.DestinationEndpoint}");
+        }
+
+        /// <summary>
         /// Visit an QUIT command.
         /// </summary>
         /// <param name="command">The command that is being visited.</param>


### PR DESCRIPTION
Other SMTP servers support proxy protocol [1] allowing load balancers
like HAProxy to tell the server the "real" address of the client making
the request.
[1] http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

I’ve tried to follow the style already in the project, but please let me know if you spot anything that can be improved. 😊