### PR TITLE
Added support for the SMTPUTF8 extension

### DIFF
--- a/Src/SmtpServer/Protocol/EhloCommand.cs
+++ b/Src/SmtpServer/Protocol/EhloCommand.cs
@@ -52,6 +52,7 @@ namespace SmtpServer.Protocol
         {
             yield return "PIPELINING";
             yield return "8BITMIME";
+            yield return "SMTPUTF8";
 
             if (session.NetworkClient.IsSecure == false && Options.ServerCertificate != null)
             {


### PR DESCRIPTION
Only thing it seems to be missing so far is the "SMTPUTF8" extension. When sending emails with "extended" characters via C# SmtpClient with the "International Delivery" setting -- it will fail. Issue #73