### PR TITLE
 Introduce EndPointStarted and EndPointStopped events on SmtpServer.

### DIFF
--- a/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
+++ b/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -88,6 +91,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Src/SmtpServer.Tests/packages.config
+++ b/Src/SmtpServer.Tests/packages.config
@@ -9,4 +9,5 @@
   <package id="xunit.core" version="2.2.0" targetFramework="net462" />
   <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net462" />
   <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net462" />
+  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net462" developmentDependency="true" />
 </packages>

--- a/Src/SmtpServer/EndPointEventArgs.cs
+++ b/Src/SmtpServer/EndPointEventArgs.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Net;
+
+namespace SmtpServer
+{
+    public class EndPointEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="endPointDefinition">The endpoint definition.</param>
+        /// <param name="localEndPoint">The locally bound endpoint.</param>
+        public EndPointEventArgs(IEndpointDefinition endPointDefinition, EndPoint localEndPoint)
+        {
+            EndPointDefinition = endPointDefinition;
+            LocalEndPoint = localEndPoint;
+        }
+
+        /// <summary>
+        /// Returns the endpoint definition.
+        /// </summary>
+        public IEndpointDefinition EndPointDefinition { get; }
+
+        /// <summary>
+        /// Returns the locally bound endpoint
+        /// </summary>
+        public EndPoint LocalEndPoint { get; }
+    }
+}


### PR DESCRIPTION
I'd like to use your SmtpServer, but it is hard to write integration tests using the code, since it is not possible to observe what port gets assigned if you configure it to port 0. To this end I introduced EndPointStarted and EndPointStopped events that make this bound port observable. Hope this makes sense.

PS. Also added xunit.runner.visualstudio to make it easier to run the tests.