### PR TITLE
Allow Exceptions in the session to be bubbled up

### DIFF
--- a/Src/SmtpServer/SessionFaultedEventArgs.cs
+++ b/Src/SmtpServer/SessionFaultedEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace SmtpServer
+{
+    public class SessionFaultedEventArgs : SessionEventArgs
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <param name="exception">The exception that occured</param>
+        public SessionFaultedEventArgs(ISessionContext context, Exception exception) : base(context)
+        {
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// Returns the exception.
+        /// </summary>
+        public Exception Exception { get; }
+    }
+}

--- a/Src/SmtpServer/SmtpSession.cs
+++ b/Src/SmtpServer/SmtpSession.cs
@@ -38,6 +38,11 @@ namespace SmtpServer
                 {
                     try
                     {
+                        if (t.Exception != null)
+                        {
+                            _taskCompletionSource.TrySetException(t.Exception.InnerExceptions);
+                        }
+
                         _taskCompletionSource.SetResult(t.IsCompleted);
                     }
                     catch


### PR DESCRIPTION

Allow Exceptions in the session to be bubbled up by raising a SessionFaulted event.