### PR TITLE
IPv6 support for EHLO Command

### DIFF
--- a/Src/SmtpServer.Tests/SmtpParserTests.cs
+++ b/Src/SmtpServer.Tests/SmtpParserTests.cs
@@ -83,6 +83,8 @@ namespace SmtpServer.Tests
         [Theory]
         [InlineData("EHLO abc-1-def.mail.com")]
         [InlineData("EHLO 192.168.1.200")]
+        [InlineData("EHLO [192.168.1.200]")]
+        [InlineData("EHLO [IPv6:ABCD:EF01:2345:6789:ABCD:EF01:2345:6789]")]
         public void CanMakeEhlo(string input)
         {
             // arrange
@@ -91,10 +93,24 @@ namespace SmtpServer.Tests
             // act
             var result = parser.TryMakeEhlo(out SmtpCommand command, out SmtpResponse errorResponse);
 
+            var ipOrDomainPart = input.Substring(5);
+
+            if (ipOrDomainPart.EndsWith("]"))
+            {
+                if (ipOrDomainPart.StartsWith("[IPv6:", StringComparison.OrdinalIgnoreCase))
+                {
+                    ipOrDomainPart = ipOrDomainPart.Substring(6, ipOrDomainPart.Length - 7);
+                }
+                else
+                {
+                    ipOrDomainPart = ipOrDomainPart.Substring(1, ipOrDomainPart.Length - 2);
+                }
+            }
+
             // assert
             Assert.True(result);
             Assert.True(command is EhloCommand);
-            Assert.Equal(input.Substring(5), ((EhloCommand)command).DomainOrAddress);
+            Assert.Equal(ipOrDomainPart, ((EhloCommand)command).DomainOrAddress);
         }
 
         [Fact]
@@ -492,6 +508,99 @@ namespace SmtpServer.Tests
             // assert
             Assert.True(made);
             Assert.Equal(input, base64);
+        }
+
+        [Fact]
+        public void CanMakeIpVersion()
+        {
+            // arrange
+            var parser = CreateParser("IPv6:");
+
+            // act
+            var result = parser.TryMakeIpVersion(out var version);
+
+            // assert
+            Assert.True(result);
+            Assert.Equal(6, version);
+        }
+
+        [Theory]
+        [InlineData("0")]
+        [InlineData("A9")]
+        [InlineData("ABC")]
+        [InlineData("ABCD")]
+        [InlineData("1BCD")]
+        [InlineData("1BC2")]
+        [InlineData("1B2D")]
+        [InlineData("1B23")]
+        [InlineData("AB23")]
+        public void CanMake16BitsHexNumber(string input)
+        {
+            // arrange
+            var parser = CreateParser(input);
+
+            // act
+            var result = parser.TryMake16BitsHexNumber(out var hexNumber);
+
+            // assert
+            Assert.True(result);
+            Assert.Equal(input, hexNumber);
+        }
+
+        [Theory]
+        [InlineData("G")]
+        [InlineData("A123B")]
+        public void CanNotMake16BitsHexNumber(string input)
+        {
+            // arrange
+            var parser = CreateParser(input);
+
+            // act
+            var result = parser.TryMake16BitsHexNumber(out var hexNumber);
+
+            // assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData("ABCD:EF01:2345:6789:ABCD:EF01:2345:6789")]
+        [InlineData("2001:DB8::8:800:200C:417A")]
+        [InlineData("FF01::101")]
+        [InlineData("::1")]
+        [InlineData("::")]
+        [InlineData("0:0:0:0:0:0:13.1.68.3")]
+        [InlineData("0:0:0:0:0:FFFF:129.144.52.38")]
+        [InlineData("::13.1.68.3")]
+        [InlineData("::FFFF:129.144.52.38")]
+        public void CanMakeIpv6AddressLiteral(string input)
+        {
+            // arrange
+            var parser = CreateParser("IPv6:" + input);
+
+            // act
+            var result = parser.TryMakeIpv6AddressLiteral(out var address);
+
+            // assert
+            Assert.True(result);
+            Assert.Equal(input, address);
+        }
+
+        [Theory]
+        [InlineData("ABCD:EF01:2345:6789:ABCD:EF01:2345")]
+        [InlineData("ABCD:EF01:2345:6789:ABCD:EF01:2345:6789:0")]
+        [InlineData("FF01:::101")]
+        [InlineData(":::1")]
+        [InlineData(":::")]
+        public void CanNotMakeIpv6AddressLiteral(string input)
+        {
+            // arrange
+            var parser = CreateParser("IPv6:" + input);
+
+            // act
+            var result = parser.TryMakeIpv6AddressLiteral(out var address);
+
+            // assert
+            Assert.False(result);
         }
     }
 }

--- a/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
+++ b/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -101,6 +102,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/SmtpServer.Tests/packages.config
+++ b/Src/SmtpServer.Tests/packages.config
@@ -10,4 +10,5 @@
   <package id="xunit.core" version="2.4.1" targetFramework="net461" />
   <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net461" />
   <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This commit adds IPv6 address parsing ability for EHLO command. Unit tests are also added for all new  parser features. IP version 6 parser methods implemented according to [IP Version 6 Addressing Architecture](https://tools.ietf.org/html/rfc4291) at section 2.2. As a side note, original coding style preserved.