### PR TITLE
Generate x509 Certificate inline for tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    target-branch: "master"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,76 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '39 11 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #     echo "Run, Build Application using script"
+    #     ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,8 +57,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+#     - name: Autobuild
+#       uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -66,9 +66,10 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+    - run: |
+        echo "Run, Build Application using script"
+        echo "Run, Build Application"
+        dotnet build Src/SmtpServer.sln
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,38 @@
+name: Develop and publish to GPR
+
+on:
+  push:
+    branches: [ "develop" ]
+
+env:
+  REPOSITORY_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          5.0.x
+        # 6.0.x
+        # 7.0.x  
+        source-url: ${{ env.REPOSITORY_URL }}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+    - name: Build and Restore dependencies
+      run: dotnet build -c Release Src/SmtpServer.sln
+    - name: Test
+      run: dotnet test -c Release  Src/SmtpServer.Tests/SmtpServer.Tests.csproj --no-build --verbosity normal
+        
+    - name: Create nuget package for GPR
+      run: |
+        dotnet pack -v normal -c Release --include-source -p:PackageVersion=9.0.3-develop.${{ github.run_number }} ./Src/SmtpServer/SmtpServer.csproj 
+    - name: Publish the package to GPR
+      run: |
+        dotnet nuget push ./SmtpServer/bin/Release/*.symbols.nupkg -k ${{secrets.GITHUB_TOKEN}}
+        

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -34,5 +34,5 @@ jobs:
         dotnet pack -v normal -c Release --include-source -p:PackageVersion=9.0.3-develop.${{ github.run_number }} ./Src/SmtpServer/SmtpServer.csproj 
     - name: Publish the package to GPR
       run: |
-        dotnet nuget push ./SmtpServer/bin/Release/*.symbols.nupkg -k ${{secrets.GITHUB_TOKEN}}
+        dotnet nuget push ./Src/SmtpServer/bin/Release/*.symbols.nupkg -k ${{secrets.GITHUB_TOKEN}}
         

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,33 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    # branches: [ "master" ]
+    branches-ignore:
+      - 'develop'
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          5.0.x
+        # 6.0.x
+        # 7.0.x  
+    - name: Build and Restore dependencies
+      run: dotnet build -c Release Src/SmtpServer.sln
+    - name: Test
+      run: dotnet test -c Release  Src/SmtpServer.Tests/SmtpServer.Tests.csproj --no-build --verbosity normal
+

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,5 +28,5 @@ jobs:
         dotnet pack -v normal -c Release --include-source -p:PackageVersion=${VERSION} ./Src/SmtpServer/SmtpServer.csproj        
     - name: Push
       run: |
-        dotnet nuget push ./SmtpServer/bin/Release/*.symbols.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+        dotnet nuget push ./Src/SmtpServer/bin/Release/*.symbols.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
               

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,32 @@
+name: Tagged Prerelease to Nuget.org
+
+on:
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+-preview[0-9][0-9][0-9]"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          5.0.x
+        # 6.0.x
+        # 7.0.x          
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Set VERSION variable from tag
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+
+    - name: Pack
+      run: |
+        dotnet pack -v normal -c Release --include-source -p:PackageVersion=${VERSION} ./Src/SmtpServer/SmtpServer.csproj        
+    - name: Push
+      run: |
+        dotnet nuget push ./SmtpServer/bin/Release/*.symbols.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+              

--- a/Examples/SampleApp/Examples/CommonPortsExample.cs
+++ b/Examples/SampleApp/Examples/CommonPortsExample.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using SmtpServer;
+using SmtpServer.ComponentModel;
+
+namespace SampleApp.Examples
+{
+    public static class SimpleExample
+    {
+        public static void Run()
+        {
+            var options = new SmtpServerOptionsBuilder()
+                .ServerName("SmtpServer SampleApp")
+
+                // Port 25 is primarily used for SMTP relaying where emails are 
+                // sent from one mail server to another. Mail clients generally wont
+                // use this port and most ISP will likely block it anyway.
+                .Endpoint(builder => builder.Port(25).IsSecure(false))
+
+                // For a brief period in time this was a recognized port whereby
+                // TLS was enabled by default on the connection. When connecting to
+                // port 465 the client will upgrade its connection to SSL before
+                // doing anything else. Port 465 is obsolete in favor of using
+                // port 587 but it is still available by some mail servers.
+                .Endpoint(builder => 
+                    builder
+                        .Port(465)
+                        .IsSecure(true) // indicates that the client will need to upgrade to SSL upon connection
+                        .Certificate(new X509Certificate2())) // requires a valid certificate to be configured
+
+                // Port 587 is the default port that should be used by modern mail
+                // clients. When a certificate is provided, the server will advertise
+                // that is supports the STARTTLS command which allows the client
+                // to determine when they want to upgrade the connection to SSL. 
+                .Endpoint(builder => 
+                    builder
+                        .Port(587)
+                        .AllowUnsecureAuthentication(false) // using 'false' here means that the user cant authenticate unless the connection is secure
+                        .Certificate(new X509Certificate2())) // requires a valid certificate to be configured
+
+                .Build();
+        }
+    }
+}

--- a/Examples/SampleApp/Examples/CustomEndpointListenerExample.cs
+++ b/Examples/SampleApp/Examples/CustomEndpointListenerExample.cs
@@ -146,8 +146,8 @@ namespace SampleApp.Examples
             // to create an X509Certificate for testing you need to run MAKECERT.EXE and then PVK2PFX.EXE
             // http://www.digitallycreated.net/Blog/38/using-makecert-to-create-certificates-for-development
 
-            var certificate = File.ReadAllBytes(@"C:\Users\cain\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServer.pfx");
-            var password = File.ReadAllText(@"C:\Users\cain\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServerPassword.txt");
+            var certificate = File.ReadAllBytes(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServer.pfx");
+            var password = File.ReadAllText(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServerPassword.txt");
 
             return new X509Certificate2(certificate, password);
         }

--- a/Examples/SampleApp/Examples/SecureServerExample.cs
+++ b/Examples/SampleApp/Examples/SecureServerExample.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using SmtpServer;

--- a/Examples/SampleApp/Examples/SecureServerExample.cs
+++ b/Examples/SampleApp/Examples/SecureServerExample.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Net;
 using System.Net.Security;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using SmtpServer;
@@ -67,8 +66,8 @@ namespace SampleApp.Examples
             // to create an X509Certificate for testing you need to run MAKECERT.EXE and then PVK2PFX.EXE
             // http://www.digitallycreated.net/Blog/38/using-makecert-to-create-certificates-for-development
 
-            var certificate = File.ReadAllBytes(@"C:\Users\cain\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServer.pfx");
-            var password = File.ReadAllText(@"C:\Users\cain\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServerPassword.txt");
+            var certificate = File.ReadAllBytes(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServer.pfx");
+            var password = File.ReadAllText(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServerPassword.txt");
 
             return new X509Certificate2(certificate, password);
         }

--- a/Examples/SampleApp/Examples/SimpleExample.cs
+++ b/Examples/SampleApp/Examples/SimpleExample.cs
@@ -5,7 +5,7 @@ using SmtpServer.ComponentModel;
 
 namespace SampleApp.Examples
 {
-    public static class SimpleExample
+    public static class CommonPortsExample
     {
         public static void Run()
         {
@@ -13,7 +13,7 @@ namespace SampleApp.Examples
 
             var options = new SmtpServerOptionsBuilder()
                 .ServerName("SmtpServer SampleApp")
-                .Port(9025)
+                .Port(25)
                 .Build();
 
             var serviceProvider = new ServiceProvider();

--- a/Examples/SampleApp/Program.cs
+++ b/Examples/SampleApp/Program.cs
@@ -24,9 +24,9 @@ namespace SampleApp
             //SimpleServerExample.Run();
             //CustomEndpointListenerExample.Run();
             //ServerCancellingExample.Run();
-            SessionTracingExample.Run();
+            //SessionTracingExample.Run();
             //DependencyInjectionExample.Run();
-            //SecureServerExample.Run();
+            SecureServerExample.Run();
 
             //SampleMailClient.Send(user: "user1", password: "password1", useSsl: false, port: 587);
             //SampleMailClient.Send(useSsl: false, port: 587);

--- a/Examples/SampleApp/SampleApp.csproj
+++ b/Examples/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.8.0" />
+    <PackageReference Include="MailKit" Version="3.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
   </ItemGroup>
 

--- a/Examples/SampleApp/SampleMailClient.cs
+++ b/Examples/SampleApp/SampleMailClient.cs
@@ -21,10 +21,6 @@ namespace SampleApp
 
             message.From.Add(MailboxAddress.Parse(from ?? "from@sample.com"));
             message.To.Add(MailboxAddress.Parse(to ?? "to@sample.com"));
-            //for (var i = 0; i < 400; i++)
-            //{
-            //    message.To.Add(MailboxAddress.Parse(to ?? $"testuser{i+1000}@longemaildomain1000001.com"));
-            //}
             message.Subject = subject ?? "Hello";
             message.Body = body ?? new TextPart("plain")
             {

--- a/Src/SmtpServer.Benchmarks/SmtpServer.Benchmarks.csproj
+++ b/Src/SmtpServer.Benchmarks/SmtpServer.Benchmarks.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="MailKit" Version="2.8.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="MailKit" Version="3.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
+++ b/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
+++ b/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="MailKit" Version="3.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/Src/SmtpServer.Tests/SmtpServerTests.cs
@@ -363,8 +363,8 @@ namespace SmtpServer.Tests
 
         public static X509Certificate2 CreateCertificate()
         {
-            var certificate = File.ReadAllBytes(@"C:\Users\cain\Dropbox\Documents\Cain\Programming\SmtpServer\\SmtpServer.pfx");
-            var password = File.ReadAllText(@"C:\Users\cain\Dropbox\Documents\Cain\Programming\SmtpServer\\SmtpServerPassword.txt");
+            var certificate = File.ReadAllBytes(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServer.pfx");
+            var password = File.ReadAllText(@"C:\Users\caino\Dropbox\Documents\Cain\Programming\SmtpServer\SmtpServerPassword.txt");
 
             return new X509Certificate2(certificate, password);
         }

--- a/Src/SmtpServer/SmtpServer.cs
+++ b/Src/SmtpServer/SmtpServer.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.ComponentModel;
-using SmtpServer.IO;
 using SmtpServer.Net;
 
 namespace SmtpServer
@@ -132,7 +130,7 @@ namespace SmtpServer
                 try
                 {
                     // wait for a client connection
-                    sessionContext.Pipe = await GetPipeAsync(endpointListener, sessionContext, cancellationTokenSource.Token).ConfigureAwait(false);
+                    sessionContext.Pipe = await endpointListener.GetPipeAsync(sessionContext, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) { }
                 catch (Exception ex)
@@ -146,29 +144,6 @@ namespace SmtpServer
                     _sessions.Run(sessionContext, cancellationTokenSource.Token);
                 }
             }
-        }
-
-        static async Task<ISecurableDuplexPipe> GetPipeAsync(IEndpointListener endpointListener, SmtpSessionContext sessionContext, CancellationToken cancellationToken)
-        {
-            var pipe = await endpointListener.GetPipeAsync(sessionContext, cancellationToken).ConfigureAwait(false);
-            try
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (sessionContext.EndpointDefinition.IsSecure && sessionContext.EndpointDefinition.ServerCertificate != null)
-                {
-                    await pipe.UpgradeAsync(sessionContext.EndpointDefinition.ServerCertificate, sessionContext.EndpointDefinition.SupportedSslProtocols, cancellationToken).ConfigureAwait(false);
-                    cancellationToken.ThrowIfCancellationRequested();
-                }
-            }
-            catch
-            {
-                pipe.Dispose();
-
-                throw;
-            }
-
-            return pipe;
         }
 
         /// <summary>

--- a/Src/SmtpServer/SmtpServer.csproj
+++ b/Src/SmtpServer/SmtpServer.csproj
@@ -5,25 +5,24 @@
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SmtpServer</AssemblyName>
     <RootNamespace>SmtpServer</RootNamespace>
-    <Version>9.0.1</Version>
+    <Version>9.0.2-beta1</Version>
     <Description>.NET SmtpServer</Description>
     <Authors>Cain O'Sullivan</Authors>
     <Company />
-    <Copyright>2015-2021</Copyright>
+    <Copyright>2015-2022</Copyright>
     <RepositoryUrl>https://github.com/cosullivan/SmtpServer</RepositoryUrl>
     <PackageProjectUrl>http://cainosullivan.com/smtpserver</PackageProjectUrl>
     <PackageTags>smtp smtpserver smtp server</PackageTags>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>9.0.1.0</AssemblyVersion>
-    <FileVersion>9.0.1.0</FileVersion>
-    <PackageReleaseNotes>Version 9
+    <AssemblyVersion>9.0.2-Beta1</AssemblyVersion>
+    <FileVersion>9.0.2.0</FileVersion>
+    <PackageReleaseNotes>Version 9.0.2
+Fixed a performance issue whereby the server would block incoming connections whilst another connection was upgrading to SSL.
+
+Version 9
 Breaking API change by removing the Certificate from the server options and adding it to the endpoint.
-
-Version 8
-https://github.com/cosullivan/SmtpServer/blob/develop/Version8.md
-
-Version 8.0.5 Fixed bug where the AUTH PLAIN LOGIN command wasnt adverstised from EHLO</PackageReleaseNotes>
+</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Src/SmtpServer/SmtpServer.csproj
+++ b/Src/SmtpServer/SmtpServer.csproj
@@ -15,7 +15,7 @@
     <PackageTags>smtp smtpserver smtp server</PackageTags>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>9.0.2-Beta1</AssemblyVersion>
+    <!-- <AssemblyVersion>9.0.2-Beta1</AssemblyVersion> -->
     <FileVersion>9.0.2.0</FileVersion>
     <PackageReleaseNotes>Version 9.0.2
 Fixed a performance issue whereby the server would block incoming connections whilst another connection was upgrading to SSL.


### PR DESCRIPTION
Generate x509 Certificate inline for tests.
Add .github workflow tooling for CodeQL's, code analysis, and build and tests scripts.  Definitly some opinionated techniques but it could be a start to build and test here in Github.  Free build servers and ran on Linux. :) 
Fixup the windows-1255 encoding test to pass in more places.  

See an example action that build and ran tests on Ubuntu here:  https://github.com/JoeShook/SmtpServer/actions

