### PR TITLE
Added AllowClientSslRenegotiation property on .NET STANDARD 2.1

### DIFF
--- a/Src/SmtpServer/EndpointDefinitionBuilder.cs
+++ b/Src/SmtpServer/EndpointDefinitionBuilder.cs
@@ -99,6 +99,21 @@ namespace SmtpServer
             return this;
         }
 
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Sets a value indicating wheter client ssl renegotiation should be allowed, this is not recommended 
+        /// since it might allow for the following vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555
+        /// .NET 7.0 has made renagotiation false by default https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/7.0/allowrenegotiation-default
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public EndpointDefinitionBuilder AllowClientSslRenegotiation(bool value = true)
+        {
+            _setters.Add(options => options.AllowClientSslRenegotiation = value);
+            return this;
+        }
+#endif
+
         /// <summary>
         /// Sets the read timeout to apply to stream operations.
         /// </summary>
@@ -154,6 +169,7 @@ namespace SmtpServer
             /// </summary>
             public bool AuthenticationRequired { get; set; }
 
+
             /// <summary>
             /// Gets a value indicating whether authentication should be allowed on an unsecure session.
             /// </summary>
@@ -173,6 +189,13 @@ namespace SmtpServer
             /// The supported SSL protocols.
             /// </summary>
             public SslProtocols SupportedSslProtocols { get; set; }
+
+#if NETSTANDARD2_1_OR_GREATER
+            /// <summary>
+            /// Gets a value indicating if during an SSL connection a client ssl renegotiation is allowed
+            /// </summary>
+            public bool AllowClientSslRenegotiation { get; set; }
+#endif
         }
 
         #endregion

--- a/Src/SmtpServer/IEndpointDefinition.cs
+++ b/Src/SmtpServer/IEndpointDefinition.cs
@@ -27,6 +27,14 @@ namespace SmtpServer
         /// </summary>
         bool AllowUnsecureAuthentication { get; }
 
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Gets a value indicating if during an SSL connection a client ssl renegotiation is allowed
+        /// </summary>
+        bool AllowClientSslRenegotiation { get; }
+#endif
+
         /// <summary>
         /// The timeout on each individual buffer read.
         /// </summary>

--- a/Src/SmtpServer/Net/EndpointListener.cs
+++ b/Src/SmtpServer/Net/EndpointListener.cs
@@ -30,6 +30,12 @@ namespace SmtpServer.Net
         }
 
         /// <summary>
+        /// During ssl connections allows the client to drop the connection and reconnect while renegotiation for a different TLS version
+        /// .NET 7.0 has set this to false to prevent the following vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555
+        /// </summary>
+        public bool AllowSslClientRenegotiation { get; set; } = false;
+
+        /// <summary>
         /// Returns a securable pipe to the endpoint.
         /// </summary>
         /// <param name="context">The session context that the pipe is being created for.</param>
@@ -50,7 +56,12 @@ namespace SmtpServer.Net
             {
                 tcpClient.Close();
                 tcpClient.Dispose();
-            });
+            })
+            {
+#if NETSTANDARD2_1_OR_GREATER
+                AllowRenegotiation = AllowSslClientRenegotiation
+#endif
+            };
         }
 
         /// <summary>

--- a/Src/SmtpServer/SmtpServer.csproj
+++ b/Src/SmtpServer/SmtpServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SmtpServer</AssemblyName>
     <RootNamespace>SmtpServer</RootNamespace>


### PR DESCRIPTION
.NET 7 made AllowRenegotiation on SslStream false by default to avoid the following potential vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555, I've added a setting to make it true in the event someone wants to set it, this only applies to .NET STANDARD 2.1, support for netstandard2.1 target framework has also been added