### PR TITLE
Add Resilience Features

### DIFF
--- a/Src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/Src/SmtpServer.Tests/SmtpServerTests.cs
@@ -16,6 +16,7 @@ using SmtpServer.Net;
 using SmtpServer.Protocol;
 using SmtpServer.Storage;
 using SmtpResponse = SmtpServer.Protocol.SmtpResponse;
+using System.Linq;
 
 namespace SmtpServer.Tests
 {
@@ -153,6 +154,15 @@ namespace SmtpServer.Tests
                 Task.Delay(TimeSpan.FromSeconds(5)).Wait();
 
                 Assert.Throws<IOException>(() => client.NoOp());
+            }
+        }
+
+        [Fact]
+        public void WillTerminateDueToTooMuchData()
+        {
+            using (CreateServer(c => c.MaxMessageSize(2, MaxMessageSizeHandling.Strict)))
+            {
+                Assert.Throws<IOException>(() => MailClient.Send(MailClient.Message(from: "test1@test.com", to: "test2@test.com", text: string.Concat(Enumerable.Repeat("Too long for 1024 bytes", 1000)))));
             }
         }
 

--- a/Src/SmtpServer/IMaxMessageSizeOptions.cs
+++ b/Src/SmtpServer/IMaxMessageSizeOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace SmtpServer
+{
+    public interface IMaxMessageSizeOptions
+    {
+        /// <summary>
+        /// Gets the maximum size of a message.
+        /// </summary>
+        int Length { get; }
+        /// <summary>
+        /// Gets the handling type an oversized message.
+        /// </summary>
+        MaxMessageSizeHandling Handling { get; }
+    }
+}

--- a/Src/SmtpServer/ISmtpServerOptions.cs
+++ b/Src/SmtpServer/ISmtpServerOptions.cs
@@ -6,9 +6,9 @@ namespace SmtpServer
     public interface ISmtpServerOptions
     {
         /// <summary>
-        /// Gets the maximum size of a message.
+        /// Gets the maximum message size option.
         /// </summary>
-        int MaxMessageSize { get; }
+        IMaxMessageSizeOptions MaxMessageSizeOptions { get; }
 
         /// <summary>
         /// The maximum number of retries before quitting the session.

--- a/Src/SmtpServer/ISmtpServerOptions.cs
+++ b/Src/SmtpServer/ISmtpServerOptions.cs
@@ -36,6 +36,11 @@ namespace SmtpServer
         TimeSpan CommandWaitTimeout { get; }
 
         /// <summary>
+        /// The timeout to use when waiting for a response from the client.
+        /// </summary>
+        TimeSpan ResponseWaitTimeout { get; }
+
+        /// <summary>
         /// The size of the buffer that is read from each call to the underlying network client.
         /// </summary>
         int NetworkBufferSize { get; }

--- a/Src/SmtpServer/MaxMessageSizeHandling.cs
+++ b/Src/SmtpServer/MaxMessageSizeHandling.cs
@@ -1,0 +1,17 @@
+﻿namespace SmtpServer
+{
+    /// <summary>
+    /// Choose how MaxMessageSize limit should be considered
+    /// </summary>
+    public enum MaxMessageSizeHandling
+    {
+        /// <summary>
+        /// Use the size limit for the SIZE extension of ESMTP
+        /// </summary>
+        Ignore = 0,
+        /// <summary>
+        /// Close the session after too much data has been sent
+        /// </summary>
+        Strict = 1,
+    }
+}

--- a/Src/SmtpServer/Protocol/EhloCommand.cs
+++ b/Src/SmtpServer/Protocol/EhloCommand.cs
@@ -69,9 +69,9 @@ namespace SmtpServer.Protocol
                 yield return "STARTTLS";
             }
 
-            if (context.ServerOptions.MaxMessageSize > 0)
+            if (context.ServerOptions.MaxMessageSizeOptions.Length > 0)
             {
-                yield return $"SIZE {context.ServerOptions.MaxMessageSize}";
+                yield return $"SIZE {context.ServerOptions.MaxMessageSizeOptions.Length}";
             }
 
             if (IsPlainLoginAllowed(context))

--- a/Src/SmtpServer/Protocol/MailCommand.cs
+++ b/Src/SmtpServer/Protocol/MailCommand.cs
@@ -45,7 +45,7 @@ namespace SmtpServer.Protocol
             var size = GetMessageSize();
 
             // check against the server supplied maximum
-            if (context.ServerOptions.MaxMessageSize > 0 && size > context.ServerOptions.MaxMessageSize)
+            if (context.ServerOptions.MaxMessageSizeOptions.Length > 0 && size > context.ServerOptions.MaxMessageSizeOptions.Length)
             {
                 await context.Pipe.Output.WriteReplyAsync(SmtpResponse.SizeLimitExceeded, cancellationToken).ConfigureAwait(false);
                 return false;

--- a/Src/SmtpServer/Protocol/MaxMessageSizeExceededException.cs
+++ b/Src/SmtpServer/Protocol/MaxMessageSizeExceededException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SmtpServer.Protocol
+{
+    public sealed class MaxMessageSizeExceededException : Exception
+    {
+        
+    }
+}

--- a/Src/SmtpServer/SmtpServerOptionsBuilder.cs
+++ b/Src/SmtpServer/SmtpServerOptionsBuilder.cs
@@ -15,6 +15,7 @@ namespace SmtpServer
         {
             var serverOptions = new SmtpServerOptions
             {
+                MaxMessageSizeOptions = new MaxMessageSizeOptions(),
                 Endpoints = new List<IEndpointDefinition>(),
                 MaxRetryCount = 5,
                 MaxAuthenticationAttempts = 3,
@@ -95,11 +96,12 @@ namespace SmtpServer
         /// <summary>
         /// Sets the maximum message size.
         /// </summary>
-        /// <param name="value">The maximum message size to allow.</param>
+        /// <param name="length">The maximum message size to allow in bytes.</param>
+        /// <param name="handling">The handling type.</param>
         /// <returns>A OptionsBuilder to continue building on.</returns>
-        public SmtpServerOptionsBuilder MaxMessageSize(int value)
+        public SmtpServerOptionsBuilder MaxMessageSize(int length, MaxMessageSizeHandling handling = MaxMessageSizeHandling.Ignore)
         {
-            _setters.Add(options => options.MaxMessageSize = value);
+            _setters.Add(options => options.MaxMessageSizeOptions = new MaxMessageSizeOptions(handling, length));
 
             return this;
         }
@@ -148,10 +150,9 @@ namespace SmtpServer
         public SmtpServerOptionsBuilder CommandWaitTimeout(TimeSpan value)
         {
             _setters.Add(options => options.CommandWaitTimeout = value);
-            
+
             return this;
         }
-
         #region SmtpServerOptions
 
         class SmtpServerOptions : ISmtpServerOptions
@@ -159,7 +160,7 @@ namespace SmtpServer
             /// <summary>
             /// Gets or sets the maximum size of a message.
             /// </summary>
-            public int MaxMessageSize { get; set; }
+            public IMaxMessageSizeOptions MaxMessageSizeOptions { get; set; }
 
             /// <summary>
             /// The maximum number of retries before quitting the session.
@@ -195,6 +196,27 @@ namespace SmtpServer
             /// The size of the buffer that is read from each call to the underlying network client.
             /// </summary>
             public int NetworkBufferSize { get; set; }
+        }
+
+        public class MaxMessageSizeOptions: IMaxMessageSizeOptions
+        {
+            /// <summary>
+            /// Gets or sets the maximum size of a message.
+            /// </summary>
+            public int Length { get; set;}
+            /// <summary>
+            /// Gets or sets the handling type an oversized message.
+            /// </summary>
+            public MaxMessageSizeHandling Handling { get; set;}
+            public MaxMessageSizeOptions(MaxMessageSizeHandling handling, int length)
+            {
+                Length = length;
+                Handling = handling;
+            }
+            public MaxMessageSizeOptions()
+            {
+
+            }
         }
 
         #endregion

--- a/Src/SmtpServer/SmtpServerOptionsBuilder.cs
+++ b/Src/SmtpServer/SmtpServerOptionsBuilder.cs
@@ -20,7 +20,8 @@ namespace SmtpServer
                 MaxRetryCount = 5,
                 MaxAuthenticationAttempts = 3,
                 NetworkBufferSize = 128,
-                CommandWaitTimeout = TimeSpan.FromMinutes(5)
+                CommandWaitTimeout = TimeSpan.FromMinutes(5),
+                ResponseWaitTimeout = TimeSpan.FromMinutes(5),
             };
 
             _setters.ForEach(setter => setter(serverOptions));
@@ -153,6 +154,18 @@ namespace SmtpServer
 
             return this;
         }
+
+        /// <summary>
+        /// Sets the timeout used when waiting for a command from the client.
+        /// </summary>
+        /// <param name="value">The timeout used when waiting for a command from the client.</param>
+        /// <returns>An OptionsBuilder to continue building on.</returns>
+        public SmtpServerOptionsBuilder ResponseWaitTimeout(TimeSpan value)
+        {
+            _setters.Add(options => options.ResponseWaitTimeout = value);
+
+            return this;
+        }
         #region SmtpServerOptions
 
         class SmtpServerOptions : ISmtpServerOptions
@@ -191,6 +204,11 @@ namespace SmtpServer
             /// The timeout to use when waiting for a command from the client.
             /// </summary>
             public TimeSpan CommandWaitTimeout { get; set; }
+
+            /// <summary>
+            /// The timeout to use when waiting for a command from the client.
+            /// </summary>
+            public TimeSpan ResponseWaitTimeout { get; set; }
 
             /// <summary>
             /// The size of the buffer that is read from each call to the underlying network client.


### PR DESCRIPTION
Adds option to enforce the message size limit in all commands.
Adds option to set a timeout for all client responses.

Mainly, the DATA command should not read infinitely from the client.

The changes for MaxMessageSize should be backwards compatible.
The changes for ResponseWaitTimeout could be considered breaking changes, but I don't think someone would like to wait more than 5 minutes for a client to send something.