### PR TITLE
Add build pipeline on create new tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,46 @@
+name: Build, Test & Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Extract Version from tag
+      id: tag
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const version = context.ref.replace('refs/tags/', '');
+          return version.slice(1);
+    - name: Change Package Version
+      working-directory: ./Src
+      run: |
+        sed -i -e "s/<Version>[a-zA-Z0-9.-]*<\/Version>/<Version>${{ steps.tag.outputs.result }}<\/Version>/g" SmtpServer/SmtpServer.csproj
+    - name: Restore dependencies
+      working-directory: ./Src
+      run: dotnet restore
+    - name: Build
+      working-directory: ./Src
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      working-directory: ./Src
+      run: |
+        dotnet test --configuration Release --no-restore --no-build --verbosity normal
+    - name: Build project and generate NuGet package
+      run: |
+        dotnet pack --configuration Release --output $GITHUB_WORKSPACE/out Src/SmtpServer/SmtpServer.csproj
+    - name: Push NuGet package
+      run: |
+        cd $GITHUB_WORKSPACE/out
+        dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_TOKEN}} --skip-duplicate --no-symbols

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,3 @@ jobs:
       working-directory: ./Src
       run: |
         dotnet test --configuration Release --no-restore --no-build --verbosity normal
-    #- name: Create NuGet packages
-    #  run: |
-    #    dotnet pack --configuration Release --output $GITHUB_WORKSPACE/out Src/SmtpServer/SmtpServer.csproj
-    #- name: Push NuGet packages
-    #  run: |
-    #    dotnet nuget push $GITHUB_WORKSPACE/out/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_TOKEN}} --skip-duplicate --no-symbols

--- a/Src/SmtpServer/SmtpServer.csproj
+++ b/Src/SmtpServer/SmtpServer.csproj
@@ -8,20 +8,16 @@
     <Version>10.0.1</Version>
     <Description>.NET SmtpServer</Description>
     <Authors>Cain O'Sullivan</Authors>
-    <Company />
     <Copyright>2015-2023</Copyright>
     <RepositoryUrl>https://github.com/cosullivan/SmtpServer</RepositoryUrl>
     <PackageProjectUrl>http://cainosullivan.com/smtpserver</PackageProjectUrl>
-    <PackageTags>smtp smtpserver smtp server</PackageTags>
-    <PackageLicenseUrl></PackageLicenseUrl>
+    <PackageTags>smtp smtpserver mailserver</PackageTags>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>10.0.0</AssemblyVersion>
-    <FileVersion>10.0.0</FileVersion>
     <PackageReleaseNotes>Version 10.0.1
 - Fixed a bug that could cause a failure to recognize commands when using a large number of recipients.
 </PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
The version in the git tag is used for versioning the nuget package.
The new pipeline publishes the Nuget package.

- Cleanup existing pipeline
- Add new pipeline for create tag
- Optimize SmtpServer project file
