### PR TITLE
Add SessionId to SessionContext, fix missing timeout for starttls

### DIFF
--- a/Src/SmtpServer.Tests/RawSmtpClient.cs
+++ b/Src/SmtpServer.Tests/RawSmtpClient.cs
@@ -10,9 +10,14 @@ namespace SmtpServer.Tests
     {
         private readonly TcpClient _tcpClient;
         private NetworkStream _networkStream;
+        private readonly string _host;
+        private readonly int _port;
 
         internal RawSmtpClient(string host, int port)
         {
+            _host = host;
+            _port = port;
+
             _tcpClient = new TcpClient();
         }
 
@@ -24,7 +29,7 @@ namespace SmtpServer.Tests
 
         internal async Task<bool> ConnectAsync()
         {
-            await _tcpClient.ConnectAsync(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 9025));
+            await _tcpClient.ConnectAsync(new IPEndPoint(IPAddress.Parse(_host), _port));
             _networkStream = _tcpClient.GetStream();
 
             var greetingResponse = await WaitForDataAsync();

--- a/Src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/Src/SmtpServer.Tests/SmtpServerTests.cs
@@ -411,6 +411,9 @@ namespace SmtpServer.Tests
                                         .Certificate(CreateCertificate())
                                    );
 
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             using var tcpClient = new TcpClient(server, port);
             using var sslStream = new SslStream(tcpClient.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null);
 
@@ -419,9 +422,6 @@ namespace SmtpServer.Tests
             if (sslStream.IsAuthenticated)
             {
                 var buffer = new byte[1024];
-
-                var stopwatch = new Stopwatch();
-                stopwatch.Start();
 
                 var welcomeByteCount = await sslStream.ReadAsync(buffer, 0, buffer.Length);
 

--- a/Src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/Src/SmtpServer.Tests/SmtpServerTests.cs
@@ -427,7 +427,7 @@ namespace SmtpServer.Tests
 
                 var emptyResponseCount = await sslStream.ReadAsync(buffer, 0, buffer.Length);
 
-                await Task.Delay(50); //Add a tolerance
+                await Task.Delay(100); //Add a tolerance
                 stopwatch.Stop();
 
                 Assert.True(emptyResponseCount == 0, "Some data received");

--- a/Src/SmtpServer/ISessionContext.cs
+++ b/Src/SmtpServer/ISessionContext.cs
@@ -10,6 +10,11 @@ namespace SmtpServer
     public interface ISessionContext
     {
         /// <summary>
+        /// A unique Id for the Session
+        /// </summary>
+        public Guid SessionId { get; }
+
+        /// <summary>
         /// Fired when a command is about to execute.
         /// </summary>
         event EventHandler<SmtpCommandEventArgs> CommandExecuting;

--- a/Src/SmtpServer/SmtpServer.csproj
+++ b/Src/SmtpServer/SmtpServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SmtpServer</AssemblyName>
     <RootNamespace>SmtpServer</RootNamespace>

--- a/Src/SmtpServer/SmtpSessionContext.cs
+++ b/Src/SmtpServer/SmtpSessionContext.cs
@@ -8,6 +8,9 @@ namespace SmtpServer
     internal sealed class SmtpSessionContext : ISessionContext
     {
         /// <inheritdoc />
+        public Guid SessionId { get; private set; }
+
+        /// <inheritdoc />
         public event EventHandler<SmtpCommandEventArgs> CommandExecuting;
 
         /// <inheritdoc />
@@ -27,6 +30,7 @@ namespace SmtpServer
         /// <param name="endpointDefinition">The endpoint definition.</param>
         internal SmtpSessionContext(IServiceProvider serviceProvider, ISmtpServerOptions options, IEndpointDefinition endpointDefinition)
         {
+            SessionId = Guid.NewGuid();
             ServiceProvider = serviceProvider;
             ServerOptions = options;
             EndpointDefinition = endpointDefinition;

--- a/Src/SmtpServer/SmtpSessionManager.cs
+++ b/Src/SmtpServer/SmtpSessionManager.cs
@@ -111,6 +111,7 @@ namespace SmtpServer
                 }
                 return false;
             }
+
             public override int GetHashCode()
             {
                 return SessionContext.SessionId.GetHashCode();

--- a/Src/SmtpServer/SmtpSessionManager.cs
+++ b/Src/SmtpServer/SmtpSessionManager.cs
@@ -102,20 +102,6 @@ namespace SmtpServer
             public SmtpSessionContext SessionContext { get; }
 
             public Task CompletionTask { get; set; }
-
-            public override bool Equals(object obj)
-            {
-                if (obj is SmtpSessionHandle other)
-                {
-                    return SessionContext.SessionId == other.SessionContext.SessionId;
-                }
-                return false;
-            }
-
-            public override int GetHashCode()
-            {
-                return SessionContext.SessionId.GetHashCode();
-            }
         }
     }
 }


### PR DESCRIPTION
Switch to .netstandard 2.1
https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1


- https://github.com/cosullivan/SmtpServer/issues/234
- https://github.com/cosullivan/SmtpServer/issues/228