### PR TITLE
Update README.md to specify AuthenticationRequired

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ var options = new SmtpServerOptionsBuilder()
     .Endpoint(builder =>
         builder
             .Port(9025, true)
-            .AllowUnsecureAuthentication(false)
+            .AllowUnsecureAuthentication(false) // this is to disallow sending PLAIN credentials without an SSL/TLS tunnel
+            .AuthenticationRequired(true)       // if this isn't explicitely set to true, the UserAuthenticator provider has no effect
             .Certificate(CreateCertificate()))
     .Build();
 


### PR DESCRIPTION
If AuthenticationRequired flag isn't explicitly changed, an authentication failure won't stop the client to send emails