### PR TITLE
Add support for custom SMTP greeting message

### DIFF
--- a/Src/SmtpServer/ISmtpServerOptions.cs
+++ b/Src/SmtpServer/ISmtpServerOptions.cs
@@ -42,5 +42,12 @@ namespace SmtpServer
         /// The size of the buffer that is read from each call to the underlying network client.
         /// </summary>
         int NetworkBufferSize { get; }
+
+        /// <summary>
+        /// Gets the custom greeting message sent by the server in response to the initial SMTP connection.
+        /// This message is returned after the client connects and before any commands are issued (e.g., "220 mail.example.com v1.0 ESMTP ready").
+        /// If not set, a default greeting will be used.
+        /// </summary>
+        string CustomGreetingMessage { get; }
     }
 }

--- a/Src/SmtpServer/ISmtpServerOptions.cs
+++ b/Src/SmtpServer/ISmtpServerOptions.cs
@@ -44,10 +44,10 @@ namespace SmtpServer
         int NetworkBufferSize { get; }
 
         /// <summary>
-        /// Gets the custom greeting message sent by the server in response to the initial SMTP connection.
-        /// This message is returned after the client connects and before any commands are issued (e.g., "220 mail.example.com v1.0 ESMTP ready").
-        /// If not set, a default greeting will be used.
+        /// Gets the custom SMTP greeting message that the server sends immediately after a client connects,
+        /// typically as the initial "220" response. The message can be dynamically generated based on the session context.
+        /// If not set, a default greeting will be used (e.g., "220 mail.example.com ESMTP ready").
         /// </summary>
-        string CustomGreetingMessage { get; }
+        Func<ISessionContext, string> CustomSmtpGreeting { get; }
     }
 }

--- a/Src/SmtpServer/SmtpServerOptionsBuilder.cs
+++ b/Src/SmtpServer/SmtpServerOptionsBuilder.cs
@@ -22,7 +22,8 @@ namespace SmtpServer
                 MaxRetryCount = 5,
                 MaxAuthenticationAttempts = 3,
                 NetworkBufferSize = 128,
-                CommandWaitTimeout = TimeSpan.FromMinutes(5)
+                CommandWaitTimeout = TimeSpan.FromMinutes(5),
+                CustomGreetingMessage = null
             };
 
             _setters.ForEach(setter => setter(serverOptions));
@@ -155,6 +156,19 @@ namespace SmtpServer
             return this;
         }
 
+        /// <summary>
+        /// Sets the custom SMTP greeting message sent to the client upon connection,
+        /// typically returned as the initial "220" response.
+        /// </summary>
+        /// <param name="value">The greeting message to send to the client (e.g., "220 mail.example.com v1.0 ESMTP ready").</param>
+        /// <returns>An OptionsBuilder to continue building on.</returns>
+        public SmtpServerOptionsBuilder CustomGreetingMessage(string value)
+        {
+            _setters.Add(options => options.CustomGreetingMessage = value);
+
+            return this;
+        }
+
         #region SmtpServerOptions
 
         class SmtpServerOptions : ISmtpServerOptions
@@ -198,6 +212,13 @@ namespace SmtpServer
             /// The size of the buffer that is read from each call to the underlying network client.
             /// </summary>
             public int NetworkBufferSize { get; set; }
+
+            /// <summary>
+            /// Gets or sets the custom greeting message sent by the server in response to the initial SMTP connection.
+            /// This message is returned after the client connects and before any commands are issued (e.g., "220 mail.example.com v1.0 ESMTP ready").
+            /// If not set, a default greeting will be used.
+            /// </summary>
+            public string CustomGreetingMessage { get; set; }
         }
 
         #endregion

--- a/Src/SmtpServer/SmtpServerOptionsBuilder.cs
+++ b/Src/SmtpServer/SmtpServerOptionsBuilder.cs
@@ -24,7 +24,7 @@ namespace SmtpServer
                 MaxAuthenticationAttempts = 3,
                 NetworkBufferSize = 128,
                 CommandWaitTimeout = TimeSpan.FromMinutes(5),
-                CustomGreetingMessage = null,
+                CustomSmtpGreeting = null,
             };
 
             _setters.ForEach(setter => setter(serverOptions));
@@ -162,11 +162,15 @@ namespace SmtpServer
         /// Sets the custom SMTP greeting message sent to the client upon connection,
         /// typically returned as the initial "220" response.
         /// </summary>
-        /// <param name="value">The greeting message to send to the client (e.g., "220 mail.example.com v1.0 ESMTP ready").</param>
+        /// <param name="smtpGreetingFunc">
+        /// A delegate that returns the greeting message to send to the client,
+        /// based on the <see cref="ISessionContext"/> (e.g., client IP, TLS state).
+        /// Example: <c>ctx => $"220 {sessionContext.ServerOptions.ServerName} ESMTP ready"</c>
+        /// </param>
         /// <returns>An OptionsBuilder to continue building on.</returns>
-        public SmtpServerOptionsBuilder CustomGreetingMessage(string value)
+        public SmtpServerOptionsBuilder CustomGreetingMessage(Func<ISessionContext, string> smtpGreetingFunc)
         {
-            _setters.Add(options => options.CustomGreetingMessage = value);
+            _setters.Add(options => options.CustomSmtpGreeting = smtpGreetingFunc);
 
             return this;
         }
@@ -220,7 +224,7 @@ namespace SmtpServer
             /// This message is returned after the client connects and before any commands are issued (e.g., "220 mail.example.com v1.0 ESMTP ready").
             /// If not set, a default greeting will be used.
             /// </summary>
-            public string CustomGreetingMessage { get; set; }
+            public Func<ISessionContext, string> CustomSmtpGreeting { get; set; }
         }
 
         #endregion

--- a/Src/SmtpServer/SmtpSession.cs
+++ b/Src/SmtpServer/SmtpSession.cs
@@ -189,14 +189,14 @@ namespace SmtpServer
         /// <returns>A task which performs the operation.</returns>
         ValueTask<FlushResult> OutputGreetingAsync(CancellationToken cancellationToken)
         {
-            if (_context.ServerOptions.CustomGreetingMessage is null)
+            if (_context.ServerOptions.CustomSmtpGreeting is null)
             {
                 var serverVersion = AssemblyVersion;
                 _context.Pipe.Output.WriteLine($"220 {_context.ServerOptions.ServerName} v{serverVersion} ESMTP ready");
             }
             else
             {
-                _context.Pipe.Output.WriteLine($"220 {_context.ServerOptions.ServerName} {_context.ServerOptions.CustomGreetingMessage}");
+                _context.Pipe.Output.WriteLine(_context.ServerOptions.CustomSmtpGreeting(_context));
             }
             
             return _context.Pipe.Output.FlushAsync(cancellationToken);

--- a/Src/SmtpServer/SmtpSession.cs
+++ b/Src/SmtpServer/SmtpSession.cs
@@ -1,20 +1,21 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using SmtpServer.Protocol;
-using System.Reflection;
+﻿using SmtpServer.ComponentModel;
 using SmtpServer.IO;
-using System.IO.Pipelines;
+using SmtpServer.Protocol;
 using SmtpServer.StateMachine;
-using SmtpServer.ComponentModel;
+using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace SmtpServer
 {
     internal sealed class SmtpSession
     {
         const string BufferKey = "SmtpSession:Buffer";
+        static readonly Version AssemblyVersion = typeof(SmtpSession).GetTypeInfo().Assembly.GetName().Version;
 
         readonly SmtpStateMachine _stateMachine;
         readonly SmtpSessionContext _context;
@@ -187,9 +188,15 @@ namespace SmtpServer
         /// <returns>A task which performs the operation.</returns>
         ValueTask<FlushResult> OutputGreetingAsync(CancellationToken cancellationToken)
         {
-            var version = typeof(SmtpSession).GetTypeInfo().Assembly.GetName().Version;
-
-            _context.Pipe.Output.WriteLine($"220 {_context.ServerOptions.ServerName} v{version} ESMTP ready");
+            if (_context.ServerOptions.CustomGreetingMessage is null)
+            {
+                var serverVersion = AssemblyVersion;
+                _context.Pipe.Output.WriteLine($"220 {_context.ServerOptions.ServerName} v{serverVersion} ESMTP ready");
+            }
+            else
+            {
+                _context.Pipe.Output.WriteLine($"220 {_context.ServerOptions.ServerName} {_context.ServerOptions.CustomGreetingMessage}");
+            }
             
             return _context.Pipe.Output.FlushAsync(cancellationToken);
         }


### PR DESCRIPTION
Introduces a CustomGreetingMessage property to ISmtpServerOptions and SmtpServerOptionsBuilder, allowing configuration of the initial SMTP greeting sent to clients. SmtpSession now uses this custom message if set, otherwise defaults to the standard greeting with server name and version.

Fix issue
-  https://github.com/cosullivan/SmtpServer/issues/187

An example of the server configuration
```cs
var options = new SmtpServerOptionsBuilder()
    .ServerName("SMTP Server")
    .Port(9025)
    .CustomGreetingMessage("Hi")
    .Build();
```

> 220 SMTP Server Hi