### PR TITLE
Add support for XOAUTH2 and OAUTHBEARER auth mechanisms

### DIFF
--- a/Src/SmtpServer.Tests/MailClient.cs
+++ b/Src/SmtpServer.Tests/MailClient.cs
@@ -81,6 +81,28 @@ namespace SmtpServer.Tests
             client.Disconnect(true);
         }
 
+#nullable enable
+        public static void Send(
+            SaslMechanism saslMechanism,
+            MimeMessage? message = null!
+        )
+        {
+            message ??= Message();
+
+            System.ArgumentNullException.ThrowIfNull(message);
+            System.ArgumentNullException.ThrowIfNull(saslMechanism);
+
+            using var client = Client();
+
+            client.Authenticate(saslMechanism);
+
+            //client.NoOp();
+
+            client.Send(message);
+            client.Disconnect(true);
+        }
+#nullable restore
+
         public static void NoOp(SecureSocketOptions options = SecureSocketOptions.Auto)
         {
             using var client = Client(options: options);

--- a/Src/SmtpServer.Tests/SmtpParserTests.cs
+++ b/Src/SmtpServer.Tests/SmtpParserTests.cs
@@ -1,12 +1,17 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
+using System.Security.Claims;
 using System.Text;
 using SmtpServer.Mail;
 using SmtpServer.Protocol;
 using SmtpServer.Text;
 using Xunit;
+using SecurityAlgorithms = Microsoft.IdentityModel.Tokens.SecurityAlgorithms;
+using SigningCredentials = Microsoft.IdentityModel.Tokens.SigningCredentials;
+using SymmetricSecurityKey = Microsoft.IdentityModel.Tokens.SymmetricSecurityKey;
 
 namespace SmtpServer.Tests
 {
@@ -147,6 +152,44 @@ namespace SmtpServer.Tests
             Assert.True(command is AuthCommand);
             Assert.Equal(AuthenticationMethod.Login, ((AuthCommand)command).Method);
             Assert.Equal("Y2Fpbi5vc3VsbGl2YW5AZ21haWwuY29t", ((AuthCommand)command).Parameter);
+        }
+
+        [Fact]
+        public void CanMakeAuthXOAuth2()
+        {
+            // arrange
+            string email = "test-user@host.com";
+            string token = GenerateJwt(email, "my-very-long-at-least-32-bytes-key");
+            string authString = $"user={email}\u0001auth=Bearer {token}\u0001\u0001";
+
+            var reader = CreateReader($"AUTH XOAUTH2 {Convert.ToBase64String(Encoding.UTF8.GetBytes(authString))}");
+
+            // act
+            var result = Parser.TryMakeAuth(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.True(result);
+            Assert.True(command is AuthCommand);
+            Assert.Equal(AuthenticationMethod.XOAuth2, ((AuthCommand) command).Method);
+        }
+
+        [Fact]
+        public void CanMakeAuthOAuthBearer()
+        {
+            // arrange
+            string email = "test-user@host.com";
+            string token = GenerateJwt(email, "my-very-long-at-least-32-bytes-key");
+            string authString = $"user={email}\u0001auth=Bearer {token}\u0001\u0001";
+
+            var reader = CreateReader($"AUTH OAUTHBEARER {Convert.ToBase64String(Encoding.UTF8.GetBytes(authString))}");
+
+            // act
+            var result = Parser.TryMakeAuth(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.True(result);
+            Assert.True(command is AuthCommand);
+            Assert.Equal(AuthenticationMethod.OAuthBearer, ((AuthCommand) command).Method);
         }
 
         [Theory]
@@ -687,6 +730,27 @@ namespace SmtpServer.Tests
 
             // assert
             Assert.False(result);
+        }
+
+        static string GenerateJwt(string nameId, string key)
+        {
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            var handler = new JwtSecurityTokenHandler();
+            var token = handler.CreateJwtSecurityToken(
+                issuer: "test-issuer",
+                audience: "smtp",
+                subject: new ClaimsIdentity(
+                [
+                    new Claim(ClaimTypes.NameIdentifier, nameId),
+                ]),
+                notBefore: DateTime.UtcNow,
+                expires: DateTime.UtcNow.AddMinutes(10),
+                signingCredentials: credentials
+            );
+
+            return handler.WriteToken(token);
         }
     }
 }

--- a/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
+++ b/Src/SmtpServer.Tests/SmtpServer.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.7.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
     <PackageReference Include="xunit" Version="2.9.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/Src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/Src/SmtpServer.Tests/SmtpServerTests.cs
@@ -1,4 +1,20 @@
-﻿using MailKit;
+﻿using System;
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit;
+using MailKit.Security;
+using Microsoft.IdentityModel.Tokens;
 using SmtpServer.Authentication;
 using SmtpServer.ComponentModel;
 using SmtpServer.Mail;
@@ -6,18 +22,6 @@ using SmtpServer.Net;
 using SmtpServer.Protocol;
 using SmtpServer.Storage;
 using SmtpServer.Tests.Mocks;
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
-using System.Net.Security;
-using System.Net.Sockets;
-using System.Security.Authentication;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 using SmtpResponse = SmtpServer.Protocol.SmtpResponse;
 
@@ -94,6 +98,68 @@ namespace SmtpServer.Tests
                 Assert.Equal("password", password);
             }
         }
+
+#nullable enable
+        [Fact]
+        public void CanAuthenticateUser_WithXOAuth2()
+        {
+            // arrange
+            string? actualUser = null;
+            string? actualBearerToken = null;
+
+            var bearerTokenAuthenticator = new DelegatingBearerTokenAuthenticator((u, bt) =>
+            {
+                actualUser = u;
+                actualBearerToken = bt;
+
+                return true;
+            });
+
+            string nameIdentifier = "user@host.com";
+            string bearerToken = GenerateJwt(nameIdentifier, "my-very-long-at-least-32-bytes-key");
+
+            using (CreateServer(endpoint => endpoint.AllowUnsecureAuthentication(), services => services.Add(bearerTokenAuthenticator)))
+            {
+                // act
+                MailClient.Send(new SaslMechanismOAuth2(nameIdentifier, bearerToken));
+
+                // assert
+                Assert.Single(MessageStore.Messages);
+                Assert.Equal(nameIdentifier, actualUser);
+                Assert.Equal(bearerToken, actualBearerToken);
+            }
+        }
+
+        [Fact]
+        public void CanAuthenticateUser_WithOAuthBearer()
+        {
+            // arrange
+            string? actualUser = null;
+            string? actualBearerToken = null;
+
+            var bearerTokenAuthenticator = new DelegatingBearerTokenAuthenticator((u, bt) =>
+            {
+                actualUser = u;
+                actualBearerToken = bt;
+
+                return true;
+            });
+
+            string nameIdentifier = "user@host.com";
+            string bearerToken = GenerateJwt(nameIdentifier, "my-very-long-at-least-32-bytes-key");
+
+            using (CreateServer(endpoint => endpoint.AllowUnsecureAuthentication(), services => services.Add(bearerTokenAuthenticator)))
+            {
+                // act
+                MailClient.Send(new SaslMechanismOAuthBearer(nameIdentifier, bearerToken));
+
+                // assert
+                Assert.Single(MessageStore.Messages);
+                Assert.Equal(nameIdentifier, actualUser);
+                Assert.Equal(bearerToken, actualBearerToken);
+            }
+        }
+#nullable restore
 
         [Theory]
         [InlineData("", "")]
@@ -639,5 +705,26 @@ namespace SmtpServer.Tests
         /// The cancellation token source for the test.
         /// </summary>
         public CancellationTokenSource CancellationTokenSource { get; }
+
+        static string GenerateJwt(string nameId, string key)
+        {
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            var handler = new JwtSecurityTokenHandler();
+            var token = handler.CreateJwtSecurityToken(
+                issuer: "test-issuer",
+                audience: "smtp",
+                subject: new ClaimsIdentity(
+                [
+                    new Claim(ClaimTypes.NameIdentifier, nameId),
+                ]),
+                notBefore: DateTime.UtcNow,
+                expires: DateTime.UtcNow.AddMinutes(10),
+                signingCredentials: credentials
+            );
+
+            return handler.WriteToken(token);
+        }
     }
 }

--- a/Src/SmtpServer/Authentication/BearerTokenAuthenticator.cs
+++ b/Src/SmtpServer/Authentication/BearerTokenAuthenticator.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// Bearer Token Authenticator
+    /// </summary>
+    public abstract class BearerTokenAuthenticator : IBearerTokenAuthenticator
+    {
+        /// <summary>
+        /// Default Bearer Token Authenticator
+        /// </summary>
+        public static readonly IBearerTokenAuthenticator Default = new DefaultBearerTokenAuthenticator();
+
+        /// <summary>
+        /// Authenticate a user account utilizing a bearer token.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <param name="user">The user to authenticate.</param>
+        /// <param name="bearerToken">The bearer token of the user.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>true if the user is authenticated, false if not.</returns>
+        public abstract Task<bool> AuthenticateAsync(
+            ISessionContext context,
+            string user,
+            string bearerToken,
+            CancellationToken cancellationToken);
+
+        sealed class DefaultBearerTokenAuthenticator : BearerTokenAuthenticator
+        {
+            /// <summary>
+            /// Authenticate a user account utilizing a bearer token.
+            /// </summary>
+            /// <param name="context">The session context.</param>
+            /// <param name="user">The user to authenticate.</param>
+            /// <param name="bearerToken">The bearer token of the user.</param>
+            /// <param name="cancellationToken">The cancellation token.</param>
+            /// <returns>true if the user is authenticated, false if not.</returns>
+            public override Task<bool> AuthenticateAsync(
+                ISessionContext context,
+                string user,
+                string bearerToken,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(true);
+            }
+        }
+    }
+}

--- a/Src/SmtpServer/Authentication/DelegatingBearerTokenAuthenticator.cs
+++ b/Src/SmtpServer/Authentication/DelegatingBearerTokenAuthenticator.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// Delegating BearerToken Authenticator
+    /// </summary>
+    public sealed class DelegatingBearerTokenAuthenticator : BearerTokenAuthenticator
+    {
+        readonly Func<ISessionContext, string, string, bool> _delegate;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="delegate">THe delegate to execute for the authentication.</param>
+        public DelegatingBearerTokenAuthenticator(Action<string, string> @delegate) : this(Wrap(@delegate)) { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="delegate">THe delegate to execute for the authentication.</param>
+        public DelegatingBearerTokenAuthenticator(Func<string, string, bool> @delegate) : this(Wrap(@delegate)) { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="delegate">THe delegate to execute for the authentication.</param>
+        public DelegatingBearerTokenAuthenticator(Func<ISessionContext, string, string, bool> @delegate)
+        {
+            _delegate = @delegate;
+        }
+
+        /// <summary>
+        /// Wrap the delegate into a function that is compatible with the signature.
+        /// </summary>
+        /// <param name="delegate">The delegate to wrap.</param>
+        /// <returns>The function that is compatible with the main signature.</returns>
+        static Func<ISessionContext, string, string, bool> Wrap(Func<string, string, bool> @delegate)
+        {
+            return (context, bearerToken, password) => @delegate(bearerToken, password);
+        }
+
+        /// <summary>
+        /// Wrap the delegate into a function that is compatible with the signature.
+        /// </summary>
+        /// <param name="delegate">The delegate to wrap.</param>
+        /// <returns>The function that is compatible with the main signature.</returns>
+        static Func<ISessionContext, string, string, bool> Wrap(Action<string, string> @delegate)
+        {
+            return (context, bearerToken, password) =>
+            {
+                @delegate(bearerToken, password);
+
+                return true;
+            };
+        }
+
+        /// <summary>
+        /// Authenticate a bearerToken account.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <param name="bearerToken">The bearerToken to authenticate.</param>
+        /// <param name="password">The password of the bearerToken.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>true if the bearerToken is authenticated, false if not.</returns>
+        public override Task<bool> AuthenticateAsync(
+            ISessionContext context,
+            string bearerToken,
+            string password,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_delegate(context, bearerToken, password));
+        }
+    }
+}

--- a/Src/SmtpServer/Authentication/DelegatingBearerTokenAuthenticatorFactory.cs
+++ b/Src/SmtpServer/Authentication/DelegatingBearerTokenAuthenticatorFactory.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// Delegating Bearer Token Authenticator Factory
+    /// </summary>
+    public class DelegatingBearerTokenAuthenticatorFactory : IBearerTokenAuthenticatorFactory
+    {
+        readonly Func<ISessionContext, IBearerTokenAuthenticator> _delegate;
+
+        /// <summary>
+        /// Delegating Bearer Authenticator Factory
+        /// </summary>
+        /// <param name="delegate"></param>
+        public DelegatingBearerTokenAuthenticatorFactory(Func<ISessionContext, IBearerTokenAuthenticator> @delegate)
+        {
+            _delegate = @delegate;
+        }
+
+        /// <summary>
+        /// Creates an instance of the service for the given session context.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <returns>The service instance for the session context.</returns>
+        public IBearerTokenAuthenticator CreateInstance(ISessionContext context)
+        {
+            return _delegate(context);
+        }
+
+    }
+}

--- a/Src/SmtpServer/Authentication/IBearerTokenAuthenticator.cs
+++ b/Src/SmtpServer/Authentication/IBearerTokenAuthenticator.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// User Authenticator Interface
+    /// </summary>
+    public interface IBearerTokenAuthenticator
+    {
+        /// <summary>
+        /// Authenticate a user account.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <param name="user">The user to authenticate.</param>
+        /// <param name="bearerToken">The bearer token.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>true if the user is authenticated, false if not.</returns>
+        Task<bool> AuthenticateAsync(ISessionContext context, string user, string bearerToken, CancellationToken cancellationToken);
+    }
+}

--- a/Src/SmtpServer/Authentication/IBearerTokenAuthenticatorFactory.cs
+++ b/Src/SmtpServer/Authentication/IBearerTokenAuthenticatorFactory.cs
@@ -1,0 +1,9 @@
+﻿using SmtpServer.ComponentModel;
+
+namespace SmtpServer.Authentication
+{
+    /// <summary>
+    /// Bearer Token Authenticator Factory Interface
+    /// </summary>
+    public interface IBearerTokenAuthenticatorFactory : ISessionContextInstanceFactory<IBearerTokenAuthenticator> { }
+}

--- a/Src/SmtpServer/ComponentModel/ServiceProvider.cs
+++ b/Src/SmtpServer/ComponentModel/ServiceProvider.cs
@@ -18,6 +18,7 @@ namespace SmtpServer.ComponentModel
 
         IEndpointListenerFactory _endpointListenerFactory;
         IUserAuthenticatorFactory _userAuthenticatorFactory;
+        IBearerTokenAuthenticatorFactory _bearerTokenAuthenticatorFactory;
         ISmtpCommandFactory _smtpCommandFactory;
         IMailboxFilterFactory _mailboxFilterFactory;
         IMessageStoreFactory _messageStoreFactory;
@@ -28,6 +29,7 @@ namespace SmtpServer.ComponentModel
         public ServiceProvider()
         {
             Add(UserAuthenticator.Default);
+            Add(BearerTokenAuthenticator.Default);
             Add(MailboxFilter.Default);
             Add(MessageStore.Default);
         }
@@ -57,6 +59,15 @@ namespace SmtpServer.ComponentModel
         public void Add(IUserAuthenticator userAuthenticator)
         {
             _userAuthenticatorFactory = new DelegatingUserAuthenticatorFactory(context => userAuthenticator);
+        }
+
+        /// <summary>
+        /// Add an instance of the bearer token authenticator.
+        /// </summary>
+        /// <param name="bearerTokenAuthenticator">The bearer token authenticator.</param>
+        public void Add(IBearerTokenAuthenticator bearerTokenAuthenticator)
+        {
+            _bearerTokenAuthenticatorFactory = new DelegatingBearerTokenAuthenticatorFactory(context => bearerTokenAuthenticator);
         }
 
         /// <summary>
@@ -119,6 +130,11 @@ namespace SmtpServer.ComponentModel
             if (serviceType == typeof(IUserAuthenticatorFactory))
             {
                 return _userAuthenticatorFactory;
+            }
+
+            if (serviceType == typeof(IBearerTokenAuthenticatorFactory))
+            {
+                return _bearerTokenAuthenticatorFactory;
             }
 
             if (serviceType == typeof(ISmtpCommandFactory))

--- a/Src/SmtpServer/Protocol/AuthCommand.cs
+++ b/Src/SmtpServer/Protocol/AuthCommand.cs
@@ -22,6 +22,9 @@ namespace SmtpServer.Protocol
 
         string _user;
         string _password;
+#nullable enable
+        string? _bearerToken;
+#nullable restore
 
         /// <summary>
         /// Constructor.
@@ -62,25 +65,65 @@ namespace SmtpServer.Protocol
                         return false;
                     }
                     break;
+                case AuthenticationMethod.XOAuth2:
+                    if (await TryXOAuth2Async(context, cancellationToken).ConfigureAwait(false) == false)
+                    {
+                        await context.Pipe.Output.WriteReplyAsync(SmtpResponse.AuthenticationFailed, cancellationToken).ConfigureAwait(false);
+                        return false;
+                    }
+                    break;
+                case AuthenticationMethod.OAuthBearer:
+                    if (await TryOAuthBearerAsync(context, cancellationToken).ConfigureAwait(false) == false)
+                    {
+                        await context.Pipe.Output.WriteReplyAsync(SmtpResponse.AuthenticationFailed, cancellationToken).ConfigureAwait(false);
+                        return false;
+                    }
+                    break;
             }
 
-            var userAuthenticator = context.ServiceProvider.GetService<IUserAuthenticatorFactory, IUserAuthenticator>(context, UserAuthenticator.Default);
-
-            using (var container = new DisposableContainer<IUserAuthenticator>(userAuthenticator))
+            if (Method == AuthenticationMethod.Plain || Method == AuthenticationMethod.Login)
             {
-                if (await container.Instance.AuthenticateAsync(context, _user, _password, cancellationToken).ConfigureAwait(false) == false)
+                var userAuthenticator = context.ServiceProvider.GetService<IUserAuthenticatorFactory, IUserAuthenticator>(context, UserAuthenticator.Default);
+
+                using (var container = new DisposableContainer<IUserAuthenticator>(userAuthenticator))
                 {
-                    var remaining = context.ServerOptions.MaxAuthenticationAttempts - ++context.AuthenticationAttempts;
-                    var response = new SmtpResponse(SmtpReplyCode.AuthenticationFailed, $"authentication failed, {remaining} attempt(s) remaining.");
-
-                    await context.Pipe.Output.WriteReplyAsync(response, cancellationToken).ConfigureAwait(false);
-
-                    if (remaining <= 0)
+                    if (await container.Instance.AuthenticateAsync(context, _user, _password, cancellationToken).ConfigureAwait(false) == false)
                     {
-                        throw new SmtpResponseException(SmtpResponse.ServiceClosingTransmissionChannel, true);
-                    }
+                        var remaining = context.ServerOptions.MaxAuthenticationAttempts - ++context.AuthenticationAttempts;
+                        var response = new SmtpResponse(SmtpReplyCode.AuthenticationFailed, $"authentication failed, {remaining} attempt(s) remaining.");
 
-                    return false;
+                        await context.Pipe.Output.WriteReplyAsync(response, cancellationToken).ConfigureAwait(false);
+
+                        if (remaining <= 0)
+                        {
+                            throw new SmtpResponseException(SmtpResponse.ServiceClosingTransmissionChannel, true);
+                        }
+
+                        return false;
+                    }
+                }
+            }
+
+            if (Method == AuthenticationMethod.XOAuth2 || Method == AuthenticationMethod.OAuthBearer)
+            {
+                var bearerTokenAuthenticator = context.ServiceProvider.GetService<IBearerTokenAuthenticatorFactory, IBearerTokenAuthenticator>(context, BearerTokenAuthenticator.Default);
+
+                using (var container = new DisposableContainer<IBearerTokenAuthenticator>(bearerTokenAuthenticator))
+                {
+                    if (await container.Instance.AuthenticateAsync(context, _user, _bearerToken, cancellationToken).ConfigureAwait(false) == false)
+                    {
+                        var remaining = context.ServerOptions.MaxAuthenticationAttempts - ++context.AuthenticationAttempts;
+                        var response = new SmtpResponse(SmtpReplyCode.AuthenticationFailed, $"authentication failed, {remaining} attempt(s) remaining.");
+
+                        await context.Pipe.Output.WriteReplyAsync(response, cancellationToken).ConfigureAwait(false);
+
+                        if (remaining <= 0)
+                        {
+                            throw new SmtpResponseException(SmtpResponse.ServiceClosingTransmissionChannel, true);
+                        }
+
+                        return false;
+                    }
                 }
             }
 
@@ -165,6 +208,101 @@ namespace SmtpServer.Protocol
 
             return true;
         }
+
+#nullable enable
+        /// <summary>
+        /// Attempt an XOAUTH2 login sequence.
+        /// </summary>
+        /// <param name="context">The execution context to operate on.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>true if the LOGIN login sequence worked, false if not.</returns>
+        async Task<bool> TryXOAuth2Async(ISessionContext context, CancellationToken cancellationToken)
+        {
+            string? oauth2Response;
+
+            if (string.IsNullOrWhiteSpace(Parameter) == false)
+            {
+                // inline
+                oauth2Response = Encoding.UTF8.GetString(Convert.FromBase64String(Parameter));
+            }
+            else
+            {
+                // interactive
+                await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.ContinueWithAuth, ""), cancellationToken);
+
+                oauth2Response = await ReadBase64EncodedLineAsync(context.Pipe.Input, cancellationToken);
+            }
+
+            if (oauth2Response != null)
+            {
+                string[] oauth2Parameters = oauth2Response.Split("\u0001", StringSplitOptions.RemoveEmptyEntries);
+
+                if (oauth2Parameters.Length > 0)
+                {
+                    string usernameComponent = oauth2Parameters[0];
+                    if (usernameComponent.StartsWith("user=", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _user = usernameComponent[5..];
+                    }
+
+                    string bearerTokenComponent = oauth2Parameters[1];
+                    if (bearerTokenComponent.StartsWith("auth=Bearer ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bearerToken = bearerTokenComponent[12..];
+                    }
+                }
+            }
+
+            return _user != null && _bearerToken != null;
+        }
+
+        /// <summary>
+        /// Attempt an OAUTHBEARER login sequence.
+        /// </summary>
+        /// <param name="context">The execution context to operate on.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>true if the LOGIN login sequence worked, false if not.</returns>
+        async Task<bool> TryOAuthBearerAsync(ISessionContext context, CancellationToken cancellationToken)
+        {
+            string? oauth2Response;
+
+            if (string.IsNullOrWhiteSpace(Parameter) == false)
+            {
+                // inline
+                oauth2Response = Encoding.UTF8.GetString(Convert.FromBase64String(Parameter));
+            }
+            else
+            {
+                // interactive
+                await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.ContinueWithAuth, ""), cancellationToken);
+
+                oauth2Response = await ReadBase64EncodedLineAsync(context.Pipe.Input, cancellationToken);
+            }
+
+            if (oauth2Response != null)
+            {
+                string[] fields = oauth2Response.Split("\u0001", StringSplitOptions.RemoveEmptyEntries);
+
+                foreach (string field in fields)
+                {
+                    if (field.StartsWith("n,a=", StringComparison.OrdinalIgnoreCase))
+                    {
+                        string identity = field[4..].TrimEnd(',');
+                        if (!string.IsNullOrWhiteSpace(identity))
+                        {
+                            _user = identity;
+                        }
+                    }
+                    else if (field.StartsWith("auth=Bearer ", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _bearerToken = field[12..];
+                    }
+                }
+            }
+
+            return _user != null && _bearerToken != null;
+        }
+#nullable restore
 
         /// <summary>
         /// Read a Base64 encoded line.

--- a/Src/SmtpServer/Protocol/AuthenticationMethod.cs
+++ b/Src/SmtpServer/Protocol/AuthenticationMethod.cs
@@ -13,6 +13,16 @@
         /// <summary>
         /// Plain
         /// </summary>
-        Plain
+        Plain,
+
+        /// <summary>
+        /// XOAuth2
+        /// </summary>
+        XOAuth2,
+
+        /// <summary>
+        /// OAuthBearer
+        /// </summary>
+        OAuthBearer
     }
 }

--- a/Src/SmtpServer/Protocol/EhloCommand.cs
+++ b/Src/SmtpServer/Protocol/EhloCommand.cs
@@ -80,9 +80,22 @@ namespace SmtpServer.Protocol
                 yield return $"SIZE {context.ServerOptions.MaxMessageSize}";
             }
 
+            var supportedLoginTypes = new List<string>();
             if (IsPlainLoginAllowed(context))
             {
-                yield return "AUTH PLAIN LOGIN";
+                supportedLoginTypes.Add("PLAIN");
+                supportedLoginTypes.Add("LOGIN");
+            }
+
+            if (IsBearerTokenLoginAllowed(context))
+            {
+                supportedLoginTypes.Add("XOAUTH2");
+                supportedLoginTypes.Add("OAUTHBEARER");
+            }
+
+            if (supportedLoginTypes.Count > 0)
+            {
+                yield return $"AUTH {string.Join(" ", supportedLoginTypes)}";
             }
 
             static bool IsPlainLoginAllowed(ISessionContext context)
@@ -94,8 +107,19 @@ namespace SmtpServer.Protocol
 
                 return context.Pipe.IsSecure || context.EndpointDefinition.AllowUnsecureAuthentication;
             }
+
+            static bool IsBearerTokenLoginAllowed(ISessionContext context)
+            {
+                if (context.ServiceProvider.GetService(typeof(IBearerTokenAuthenticatorFactory)) == null
+                    && context.ServiceProvider.GetService(typeof(IBearerTokenAuthenticator)) == null)
+                {
+                    return false;
+                }
+
+                return context.Pipe.IsSecure || context.EndpointDefinition.AllowUnsecureAuthentication;
+            }
         }
-        
+
         /// <summary>
         /// Gets the domain name or address literal.
         /// </summary>

--- a/Src/SmtpServer/Protocol/SmtpParser.cs
+++ b/Src/SmtpServer/Protocol/SmtpParser.cs
@@ -671,6 +671,18 @@ namespace SmtpServer.Protocol
                 return true;
             }
 
+            if (reader.TryMake(TryMakeXOAuth2Literal))
+            {
+                authenticationMethod = AuthenticationMethod.XOAuth2;
+                return true;
+            }
+
+            if (reader.TryMake(TryMakeOAuthBearerLiteral))
+            {
+                authenticationMethod = AuthenticationMethod.OAuthBearer;
+                return true;
+            }
+
             authenticationMethod = default;
             return false;
         }
@@ -733,6 +745,68 @@ namespace SmtpServer.Protocol
                 command[2] = 'A';
                 command[3] = 'I';
                 command[4] = 'N';
+
+                return text.CaseInsensitiveStringEquals(ref command);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Try to make the XOAUTH2 text sequence.
+        /// </summary>
+        /// <param name="reader">The reader to perform the operation on.</param>
+        /// <returns>true if the XOAUTH2 text sequence could be made, false if not.</returns>
+        public bool TryMakeXOAuth2Literal(ref TokenReader reader)
+        {
+            bool isXOAuth = false;
+            bool isVersion2 = false;
+
+            if (reader.TryMake(TryMakeText, out var text))
+            {
+                Span<char> command = stackalloc char[6];
+                command[0] = 'X';
+                command[1] = 'O';
+                command[2] = 'A';
+                command[3] = 'U';
+                command[4] = 'T';
+                command[5] = 'H';
+
+                isXOAuth = text.CaseInsensitiveStringEquals(ref command);
+            }
+
+            if (isXOAuth && reader.TryMake(TryMakeNumber, out var number))
+            {
+                Span<char> command = stackalloc char[1];
+                command[0] = '2';
+
+                isVersion2 = number.CaseInsensitiveStringEquals(ref command);
+            }
+
+            return isXOAuth && isVersion2;
+        }
+
+        /// <summary>
+        /// Try to make the OAUTHBEARER text sequence.
+        /// </summary>
+        /// <param name="reader">The reader to perform the operation on.</param>
+        /// <returns>true if the XOAUTH2 text sequence could be made, false if not.</returns>
+        public bool TryMakeOAuthBearerLiteral(ref TokenReader reader)
+        {
+            if (reader.TryMake(TryMakeText, out var text))
+            {
+                Span<char> command = stackalloc char[11];
+                command[0] = 'O';
+                command[1] = 'A';
+                command[2] = 'U';
+                command[3] = 'T';
+                command[4] = 'H';
+                command[5] = 'B';
+                command[6] = 'E';
+                command[7] = 'A';
+                command[8] = 'R';
+                command[9] = 'E';
+                command[10] = 'R';
 
                 return text.CaseInsensitiveStringEquals(ref command);
             }


### PR DESCRIPTION
I found SmtpServer while trying to get my team off of Papercut, since Papercut forces developers to write SMTP-facing code that supports cleartext and no authentication. SmtpServer met all of my needs, with the exception of OAUTHBEARER and XOAUTH2 authentication mechanisms.

This PR adds support for SASL XOAUTH2 and SASL OAUTHBEARER, since I need something that will respond positively to those login requests in a bench testing scenario.

I added support for XOAUTH2 and OAUTHBEARER by adding separate `BearerTokenAuthenticator` related authentication classes. There are many parallels to the existing `PasswordAuthenticator` classes, but ultimately I thought it would be beneficial to keep them separate in case someone wants to enable a server that supports both `AUTH PLAIN`/`LOGIN` and `AUTH XOAUTH2`/`OAUTHBEARER`.

One part I was not entirely sure about is how to decode `AUTH LOGIN XOAUTH2` within `SmtpParser`. It seemed like I should have been able to call `reader.TryMake(TryMakeTextOrNumber, out var text)` to obtain a sequence from the buffer that had both a string and number in it, but tokenization appears to isolate text strings from number strings. If there's a more idiomatic way of fetching an alphanumeric string in this case, let me know and I'll update this PR.

Here's a sample:

```c#
async Task Main(CancellationToken token)
{
  var options = new SmtpServerOptionsBuilder()
    .ServerName("localhost")
    .Port(1125)
    .Build();

  var serviceProvider = new ServiceProvider();
  serviceProvider.Add(new CustomBearerTokenAuthenticator());

  var smtpServer = new SmtpServer.SmtpServer(options, serviceProvider);

  await smtpServer.StartAsync(token);
}

public class CustomBearerTokenAuthenticator : IBearerTokenAuthenticator, IBearerTokenAuthenticatorFactory
{
  public Task<bool> AuthenticateAsync(ISessionContext context, string user, string bearerToken, CancellationToken token)
  {
    // If bearer token is a JWT,  you could load it using JwtSecurityTokenHandler and validate issuer, dates, signature, etc.
    Console.WriteLine("CustomBearerTokenAuthenticator: User is valid (User={0} Token={1})", user, bearerToken);
  
    return Task.FromResult(true);
  }
  
  public IBearerTokenAuthenticator CreateInstance(ISessionContext context)
  {
    return new CustomBearerTokenAuthenticator();
  }
}
```

Client code (assuming MailKit)
```c#
using var smtpClient = new SmtpClient();
await smtpClient.ConnectAsync("localhost", 1125);
var credential = new SaslMechanismOAuth2("test-user", "1234567890");
await smtpClient.AuthenticateAsync(credential);
await smtpClient.DisconnectAsync(true);
```
