### PR TITLE
Fix SmtpServerOptionsBuilder naming for CustomSmtpGreeting

### DIFF
--- a/Src/SmtpServer/SmtpServerOptionsBuilder.cs
+++ b/Src/SmtpServer/SmtpServerOptionsBuilder.cs
@@ -165,10 +165,10 @@ namespace SmtpServer
         /// <param name="smtpGreetingFunc">
         /// A delegate that returns the greeting message to send to the client,
         /// based on the <see cref="ISessionContext"/> (e.g., client IP, TLS state).
-        /// Example: <c>ctx => $"220 {sessionContext.ServerOptions.ServerName} ESMTP ready"</c>
+        /// Example: <c>sessionContext => $"220 {sessionContext.ServerOptions.ServerName} ESMTP ready"</c>
         /// </param>
         /// <returns>An OptionsBuilder to continue building on.</returns>
-        public SmtpServerOptionsBuilder CustomGreetingMessage(Func<ISessionContext, string> smtpGreetingFunc)
+        public SmtpServerOptionsBuilder CustomSmtpGreeting(Func<ISessionContext, string> smtpGreetingFunc)
         {
             _setters.Add(options => options.CustomSmtpGreeting = smtpGreetingFunc);
 


### PR DESCRIPTION
The change renames the `CustomGreetingMessage` method to `CustomSmtpGreeting` and updates the example delegate parameter to use a more descriptive variable name (`sessionContext`) for clarity.

```cs
var options = new SmtpServerOptionsBuilder()
    .ServerName("SMTP Server")
    .Port(9025)
    .CustomSmtpGreeting(MyCustomSmtpGreeting)
    .Build();

private static string MyCustomSmtpGreeting(ISessionContext sessionContext)
{
    return $"220 {sessionContext.ServerOptions.ServerName} hello";
}
```