### PR TITLE
Handle SmtpResponseException in DataCommand

### DIFF
--- a/Src/SmtpServer/Protocol/DataCommand.cs
+++ b/Src/SmtpServer/Protocol/DataCommand.cs
@@ -58,9 +58,14 @@ namespace SmtpServer.Protocol
                     
                 await context.Pipe.Output.WriteReplyAsync(response, cancellationToken).ConfigureAwait(false);
             }
+            catch (SmtpResponseException)
+            {
+                return false;
+            }
             catch (Exception)
             {
                 await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.TransactionFailed), cancellationToken).ConfigureAwait(false);
+                return false;
             }
 
             return true;


### PR DESCRIPTION
Added a catch block for SmtpResponseException in DataCommand to return false when this exception occurs, improving error handling during SMTP data processing.

**Current**
```
554

552 message size exceeds fixed maximium message size
```

**New**
```
552 message size exceeds fixed maximium message size
```