### PR TITLE
Fix StackOverflowException on StringUtil.Create

### DIFF
--- a/Src/SmtpServer/Text/StringUtil.cs
+++ b/Src/SmtpServer/Text/StringUtil.cs
@@ -18,6 +18,11 @@ namespace SmtpServer.Text
                 return null;
             }
 
+            if (sequence.Length > ushort.MaxValue)
+            {
+                return null;
+            }
+
             if (sequence.IsSingleSegment)
             {
                 var span = sequence.First.Span;

--- a/Src/SmtpServer/Text/StringUtil.cs
+++ b/Src/SmtpServer/Text/StringUtil.cs
@@ -11,26 +11,21 @@ namespace SmtpServer.Text
             return Create(sequence, Encoding.ASCII);
         }
 
-        internal static unsafe string Create(ReadOnlySequence<byte> sequence, Encoding encoding)
+        internal static string Create(ReadOnlySequence<byte> sequence, Encoding encoding)
         {
             if (sequence.Length == 0)
             {
                 return null;
             }
 
-            if (sequence.Length > ushort.MaxValue)
+            if (sequence.Length > short.MaxValue)
             {
                 return null;
             }
 
             if (sequence.IsSingleSegment)
             {
-                var span = sequence.First.Span;
-
-                fixed (byte* ptr = span)
-                {
-                    return encoding.GetString(ptr, span.Length);
-                }
+                return encoding.GetString(sequence.First.Span);
             }
             else
             {
@@ -48,10 +43,7 @@ namespace SmtpServer.Text
                     }
                 }
 
-                fixed (byte* ptr = buffer)
-                {
-                    return encoding.GetString(ptr, buffer.Length);
-                }
+                return encoding.GetString(buffer);
             }
         }
 


### PR DESCRIPTION
This pull request introduces stricter validation for mailbox creation in the SMTP parser to prevent malformed or excessively large mailbox names from being accepted. The main changes are focused on enhancing error handling and input validation when constructing mailbox objects.

**Mailbox creation validation and error handling:**

* Updated `TryMakeMailbox` in `SmtpParser.cs` to throw an `SmtpResponseException` with `MailboxNameNotAllowed` if mailbox creation fails due to invalid input, instead of silently returning null.
* Improved the `CreateMailbox` helper to check for null values after converting the local part and domain/address, ensuring that mailbox objects are only created with valid data.

**Input size validation:**

* Added a check in `StringUtil.Create` to return null if the input sequence length exceeds `ushort.MaxValue`, preventing creation of mailbox names that are too large.

```cs
Span<byte> buffer = stackalloc byte[(int)sequence.Length];
```