### PR TITLE
Add SMTPUTF8 to supported extensions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ SmtpServer currently supports the following extensions:
 - SIZE
 - PIPELINING
 - 8BITMIME
+- SMTPUTF8
 - AUTH PLAIN LOGIN
 
 ## Installation


### PR DESCRIPTION
Updated the documentation to include SMTPUTF8 in the list of supported SMTP extensions.