### PR TITLE
Preserve UTF-8 SMTP domains

### DIFF
--- a/src/SmtpServer.Tests/SmtpParserTests.cs
+++ b/src/SmtpServer.Tests/SmtpParserTests.cs
@@ -102,6 +102,7 @@ namespace SmtpServer.Tests
         [InlineData("EHLO abc-1-def.mail.com", "abc-1-def.mail.com")]
         [InlineData("EHLO 192.168.1.200", "192.168.1.200")]
         [InlineData("EHLO [192.168.1.200]", "192.168.1.200")]
+        [InlineData("EHLO dæmi.is", "dæmi.is")]
         [InlineData("EHLO [IPv6:ABCD:EF01:2345:6789:ABCD:EF01:2345:6789]", "IPv6:ABCD:EF01:2345:6789:ABCD:EF01:2345:6789")]
         public void CanMakeEhlo(string input, string domainOrAddress)
         {
@@ -153,6 +154,7 @@ namespace SmtpServer.Tests
         [InlineData("MAIL FROM:<cain.osullivan@gmail.com>", "cain.osullivan", "gmail.com")]
         [InlineData(@"MAIL FROM:<""Abc@def""@example.com>", "Abc@def", "example.com")]
         [InlineData("MAIL FROM:<pelé@example.com> SMTPUTF8", "pelé", "example.com", "SMTPUTF8")]
+        [InlineData("MAIL FROM:<þorsteinn@dæmi.is> SMTPUTF8", "þorsteinn", "dæmi.is", "SMTPUTF8")]
         public void CanMakeMail(string input, string user, string host, string extension = null)
         {
             // arrange
@@ -226,6 +228,7 @@ namespace SmtpServer.Tests
         [InlineData("RCPT TO:<cain.osullivan@gmail.com>", "cain.osullivan", "gmail.com")]
         [InlineData(@"RCPT TO:<""Abc@def""@example.com>", "Abc@def", "example.com")]
         [InlineData("RCPT TO:<pelé@example.com>", "pelé", "example.com")]
+        [InlineData("RCPT TO:<þorsteinn@dæmi.is>", "þorsteinn", "dæmi.is")]
         [InlineData("RCPT TO:<@example1.com:someone@example.com>", "someone", "example.com")]
         [InlineData("RCPT TO:<@example1.com,@example2.com:someone@example.com>", "someone", "example.com")]
         [InlineData("RCPT TO:<example/example@example.com>", "example/example", "example.com")]

--- a/src/SmtpServer/Protocol/SmtpParser.cs
+++ b/src/SmtpServer/Protocol/SmtpParser.cs
@@ -89,7 +89,7 @@ namespace SmtpServer.Protocol
 
             if (reader.TryMake(TryMakeDomain, out var domain))
             {
-                command = _smtpCommandFactory.CreateHelo(StringUtil.Create(domain));
+                command = _smtpCommandFactory.CreateHelo(StringUtil.Create(domain, Encoding.UTF8));
                 return true;
             }
 
@@ -148,7 +148,7 @@ namespace SmtpServer.Protocol
 
             if (reader.TryMake(TryMakeDomain, out var domain))
             {
-                command = _smtpCommandFactory.CreateEhlo(StringUtil.Create(domain));
+                command = _smtpCommandFactory.CreateEhlo(StringUtil.Create(domain, Encoding.UTF8));
                 return true;
             }
 
@@ -1119,7 +1119,7 @@ namespace SmtpServer.Protocol
                     return null;
                 }
 
-                var tempDomain = StringUtil.Create(domainOrAddress);
+                var tempDomain = StringUtil.Create(domainOrAddress, Encoding.UTF8);
                 if (tempDomain == null)
                 {
                     return null;


### PR DESCRIPTION
## Summary

  Preserves UTF-8 domain names when SMTP command parsing materializes domain strings for `HELO`, `EHLO`, `MAIL FROM`, and `RCPT TO`.

  ## Root cause

  SmtpServer already tokenizes bytes >= `0x80` as text and advertises `SMTPUTF8`. The mailbox local-part path decoded with UTF-8, but the domain side still used the default ASCII helper. That meant internationalized
  domains such as `dæmi.is` were not preserved after parsing.

  ## Changes

  - Decode `HELO` and `EHLO` domains with UTF-8.
  - Decode mailbox domains with UTF-8 when creating parsed mailbox addresses.
  - Add parser coverage for Icelandic examples:
    - `EHLO dæmi.is`
    - `MAIL FROM:<þorsteinn@dæmi.is> SMTPUTF8`
    - `RCPT TO:<þorsteinn@dæmi.is>`

  ## Validation

  - `dotnet build src/SmtpServer/SmtpServer.csproj`
  - `dotnet build src/SmtpServer.Tests/SmtpServer.Tests.csproj`
  - `git diff --check`

  Full test execution was not run on my host because the tests target `net8.0`, while the installed runtimes are .NET 9 and .NET 10.

