### PR TITLE
Fix package version metadata

### DIFF
--- a/src/SmtpServer/SmtpServer.csproj
+++ b/src/SmtpServer/SmtpServer.csproj
@@ -5,7 +5,7 @@
     <LangVersion>8.0</LangVersion>
     <AssemblyName>SmtpServer</AssemblyName>
     <RootNamespace>SmtpServer</RootNamespace>
-    <Version>10.0.1</Version>
+    <Version>11.1.0</Version>
     <Description>High-performance, flexible SMTP server implementation for .NET with support for ESMTP, TLS, authentication, and custom message handling.</Description>
     <Authors>Cain O'Sullivan</Authors>
     <Copyright>2015-2023</Copyright>


### PR DESCRIPTION
Summary
Updates the package metadata version from 10.0.1 to 11.1.0, matching the current top changelog entry.

Impact
Ordinary dotnet build / dotnet pack now emits SmtpServer.11.1.0.nupkg without requiring explicit /p:Version or /p:PackageVersion overrides.

Validation
dotnet build src/SmtpServer/SmtpServer.csproj -c Release
dotnet pack src/SmtpServer/SmtpServer.csproj -c Release --no-build -o /tmp/smtpserver-packages
git diff --check
The build still reports the existing XML documentation warning in AuthCommand and the package still reports the existing missing-readme NuGet warning.