### PR TITLE
Support RCPT ESMTP parameters

### DIFF
--- a/src/SmtpServer.Tests/SmtpParserTests.cs
+++ b/src/SmtpServer.Tests/SmtpParserTests.cs
@@ -244,6 +244,41 @@ namespace SmtpServer.Tests
             Assert.Equal(host, ((RcptCommand)command).Address.Host);
         }
 
+        [Fact]
+        public void CanMakeRcptWithParameters()
+        {
+            // arrange
+            var reader = CreateReader("RCPT TO:<cain.osullivan@gmail.com> NOTIFY=SUCCESS,FAILURE ORCPT=rfc822;cain.osullivan@gmail.com");
+
+            // act
+            var result = Parser.TryMakeRcpt(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.True(result);
+            Assert.True(command is RcptCommand);
+            var rcpt = (RcptCommand)command;
+            Assert.Equal("cain.osullivan", rcpt.Address.User);
+            Assert.Equal("gmail.com", rcpt.Address.Host);
+            Assert.Equal(2, rcpt.Parameters.Count);
+            Assert.Equal("SUCCESS,FAILURE", rcpt.Parameters["NOTIFY"]);
+            Assert.Equal("rfc822;cain.osullivan@gmail.com", rcpt.Parameters["ORCPT"]);
+        }
+
+        [Fact]
+        public void CanNotMakeRcptWithInvalidParameters()
+        {
+            // arrange
+            var reader = CreateReader("RCPT TO:<cain.osullivan@gmail.com> NOTIFY=");
+
+            // act
+            var result = Parser.TryMakeRcpt(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.False(result);
+            Assert.Null(command);
+            Assert.NotNull(errorResponse);
+        }
+
         [Theory]
         [InlineData("RCPT TO:<someone@@example.com>")]
         [InlineData("RCPT TO:<someone@example..com>")]

--- a/src/SmtpServer/Protocol/ISmtpCommandFactory.cs
+++ b/src/SmtpServer/Protocol/ISmtpCommandFactory.cs
@@ -39,6 +39,15 @@ namespace SmtpServer.Protocol
         SmtpCommand CreateRcpt(IMailbox address);
 
         /// <summary>
+        /// Create a RCPT command.
+        /// </summary>
+        /// <param name="address">The address that the mail is to.</param>
+        /// <param name="parameters">The optional parameters for the recipient.</param>
+        /// <returns>The RCPT command.</returns>
+        SmtpCommand CreateRcpt(IMailbox address, IReadOnlyDictionary<string, string> parameters)
+            => CreateRcpt(address);
+
+        /// <summary>
         /// Create a DATA command.
         /// </summary>
         /// <returns>The DATA command.</returns>

--- a/src/SmtpServer/Protocol/RcptCommand.cs
+++ b/src/SmtpServer/Protocol/RcptCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.ComponentModel;
@@ -22,9 +23,19 @@ namespace SmtpServer.Protocol
         /// Constructor.
         /// </summary>
         /// <param name="address">The address.</param>
-        public RcptCommand(IMailbox address) : base(Command)
+        public RcptCommand(IMailbox address) : this(address, new Dictionary<string, string>())
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="address">The address.</param>
+        /// <param name="parameters">The optional parameters for the recipient.</param>
+        public RcptCommand(IMailbox address, IReadOnlyDictionary<string, string> parameters) : base(Command)
         {
             Address = address;
+            Parameters = parameters;
         }
 
         /// <summary>
@@ -59,5 +70,10 @@ namespace SmtpServer.Protocol
         /// Gets the address that the mail is to.
         /// </summary>
         public IMailbox Address { get; }
+
+        /// <summary>
+        /// The list of extended recipient parameters.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Parameters { get; }
     }
 }

--- a/src/SmtpServer/Protocol/SmtpCommandFactory.cs
+++ b/src/SmtpServer/Protocol/SmtpCommandFactory.cs
@@ -30,7 +30,13 @@ namespace SmtpServer.Protocol
         /// <inheritdoc />
         public virtual SmtpCommand CreateRcpt(IMailbox address)
         {
-            return new RcptCommand(address);
+            return CreateRcpt(address, new Dictionary<string, string>());
+        }
+
+        /// <inheritdoc />
+        public virtual SmtpCommand CreateRcpt(IMailbox address, IReadOnlyDictionary<string, string> parameters)
+        {
+            return new RcptCommand(address, parameters);
         }
 
         /// <inheritdoc />

--- a/src/SmtpServer/Protocol/SmtpParser.cs
+++ b/src/SmtpServer/Protocol/SmtpParser.cs
@@ -313,9 +313,20 @@ namespace SmtpServer.Protocol
                 return false;
             }
 
-            // TODO: support optional service extension parameters here
+            reader.Skip(TokenKind.Space);
 
-            command = _smtpCommandFactory.CreateRcpt(mailbox);
+            IReadOnlyDictionary<string, string> parameters;
+            if (reader.Peek().Kind == TokenKind.None)
+            {
+                parameters = new Dictionary<string, string>();
+            }
+            else if (reader.TryMake(TryMakeMailParameters, out parameters) == false)
+            {
+                errorResponse = SmtpResponse.SyntaxError;
+                return false;
+            }
+
+            command = _smtpCommandFactory.CreateRcpt(mailbox, parameters);
             return true;
         }
 

--- a/src/SmtpServer/Tracing/TracingSmtpCommandVisitor.cs
+++ b/src/SmtpServer/Tracing/TracingSmtpCommandVisitor.cs
@@ -107,7 +107,9 @@ namespace SmtpServer.Tracing
         /// <param name="command">The command that is being visited.</param>
         protected override void Visit(RcptCommand command)
         {
-            _output.WriteLine("RCPT: Address={0}", command.Address.AsAddress());
+            _output.WriteLine("RCPT: Address={0} Parameters={1}",
+                command.Address.AsAddress(),
+                string.Join(",", command.Parameters.Select(kvp => $"{kvp.Key}={kvp.Value}")));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds parser and command support for optional ESMTP parameters on `RCPT TO` commands.

## Changes

- Parse trailing ESMTP parameters after the RCPT path.
- Expose parsed recipient parameters on `RcptCommand.Parameters`.
- Add a compatibility overload to `ISmtpCommandFactory.CreateRcpt` so existing implementations that only override `CreateRcpt(IMailbox)` continue to work.
- Update `SmtpCommandFactory` and command tracing to include RCPT parameters.
- Add parser tests for valid DSN-style parameters and invalid parameter syntax.

## Validation

- `dotnet build src/SmtpServer/SmtpServer.csproj`
- `dotnet build src/SmtpServer.Tests/SmtpServer.Tests.csproj`
- `git diff --check`

`dotnet test src/SmtpServer.Tests/SmtpServer.Tests.csproj --filter "FullyQualifiedName~SmtpParserTests" --no-build` could not execute on this host because the test project targets `net8.0` and this machine only has .NET 9/10 runtimes installed.

Existing warnings remain: XML docs in `AuthCommand`, the package missing-readme warning, MailKit vulnerability warning, and existing xUnit analyzer warnings.