### PR TITLE
SS-3 Fix PROXY TCP version validation

### DIFF
--- a/src/SmtpServer.Tests/SmtpParserTests.cs
+++ b/src/SmtpServer.Tests/SmtpParserTests.cs
@@ -312,6 +312,24 @@ namespace SmtpServer.Tests
             Assert.Equal(16789, ((ProxyCommand)command).DestinationEndpoint.Port);
         }
 
+        [Theory]
+        [InlineData("PROXY TCP5 192.168.1.1 192.168.1.2 1234 16789")]
+        [InlineData("PROXY TCP46 192.168.1.1 192.168.1.2 1234 16789")]
+        [InlineData("PROXY TCPA 192.168.1.1 192.168.1.2 1234 16789")]
+        public void CanNotMakeProxyWithInvalidTcpVersion(string input)
+        {
+            // arrange
+            var reader = CreateReader(input);
+
+            // act
+            var result = Parser.TryMakeProxy(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.False(result);
+            Assert.Null(command);
+            Assert.Null(errorResponse);
+        }
+
         [Fact]
         public void CanMakeAtom()
         {

--- a/src/SmtpServer/Protocol/SmtpParser.cs
+++ b/src/SmtpServer/Protocol/SmtpParser.cs
@@ -845,7 +845,7 @@ namespace SmtpServer.Protocol
             }
 
             var token = reader.Take();
-            if (token.Kind != TokenKind.Number && token.Text[0] != '4')
+            if (token.Kind != TokenKind.Number || token.Text.Length != 1 || token.Text[0] != '4')
             {
                 return false;
             }
@@ -869,7 +869,7 @@ namespace SmtpServer.Protocol
             }
 
             var token = reader.Take();
-            if (token.Kind != TokenKind.Number && token.Text[0] != '6')
+            if (token.Kind != TokenKind.Number || token.Text.Length != 1 || token.Text[0] != '6')
             {
                 return false;
             }


### PR DESCRIPTION
## Summary

Fixes PROXY v1 TCP version validation in `SmtpParser` so TCP4 and TCP6 parsing only accepts the exact single-digit version token expected by each branch.

## Root Cause

The TCP4/TCP6 parser checks used `&&` when rejecting invalid tokens, which allowed invalid numeric versions such as `TCP5` or multi-digit variants such as `TCP46` to pass the version check and continue parsing.

## Changes

- Require the TCP version token to be numeric, single-character, and equal to `4` for TCP4 parsing.
- Require the TCP version token to be numeric, single-character, and equal to `6` for TCP6 parsing.
- Add regression coverage for invalid PROXY TCP version inputs.

## Validation

- `DOTNET_ROLL_FORWARD=Major dotnet test src/SmtpServer.Tests/SmtpServer.Tests.csproj`
- Upstream-based branch result: 120 passed, 1 skipped.

## Jira

- SS-3
