### PR TITLE
SS-2 Tighten SMTP parser syntax handling

### DIFF
--- a/src/SmtpServer.Tests/SmtpParserTests.cs
+++ b/src/SmtpServer.Tests/SmtpParserTests.cs
@@ -37,6 +37,24 @@ namespace SmtpServer.Tests
             Assert.Equal(SmtpReplyCode.CommandNotImplemented, errorResponse.ReplyCode);
         }
 
+        [Theory]
+        [InlineData("HELO abc.example.com extra")]
+        [InlineData("MAIL FROM:<sender@example.com> SIZE=")]
+        public void CanReturnSyntaxErrorForMalformedKnownCommand(string input)
+        {
+            // arrange
+            var buffer = Encoding.UTF8.GetBytes(input);
+            var sequence = new ReadOnlySequence<byte>(buffer, 0, buffer.Length);
+
+            // act
+            var result = Parser.TryMake(ref sequence, out var command, out var errorResponse);
+
+            // assert
+            Assert.False(result);
+            Assert.Null(command);
+            Assert.Equal(SmtpReplyCode.SyntaxError, errorResponse.ReplyCode);
+        }
+
         [Fact]
         public void CanMakeQuit()
         {
@@ -84,6 +102,8 @@ namespace SmtpServer.Tests
         [InlineData("HELO abc.")]
         [InlineData("HELO -abc.com")]
         [InlineData("HELO ////")]
+        [InlineData("HELO abc.example.com extra")]
+        [InlineData("HELO [192.168.1.200] extra")]
         public void CanNotMakeHelo(string input)
         {
             // arrange
@@ -115,6 +135,23 @@ namespace SmtpServer.Tests
             Assert.True(result);
             Assert.True(command is EhloCommand);
             Assert.Equal(domainOrAddress, ((EhloCommand)command).DomainOrAddress);
+        }
+
+        [Theory]
+        [InlineData("EHLO abc.example.com extra")]
+        [InlineData("EHLO [192.168.1.200] extra")]
+        public void CanNotMakeEhlo(string input)
+        {
+            // arrange
+            var reader = CreateReader(input);
+
+            // act
+            var result = Parser.TryMakeEhlo(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.False(result);
+            Assert.Null(command);
+            Assert.NotNull(errorResponse);
         }
 
         [Fact]
@@ -209,6 +246,9 @@ namespace SmtpServer.Tests
 
         [Theory]
         [InlineData("MAIL FROM:cain")]
+        [InlineData("MAIL FROM:<cain.osullivan@gmail.com> SIZE=")]
+        [InlineData("MAIL FROM:<cain.osullivan@gmail.com> =BAD")]
+        [InlineData("MAIL FROM:<cain.osullivan@gmail.com> SIZE=123 =BAD")]
         public void CanNotMakeMail(string input)
         {
             // arrange

--- a/src/SmtpServer/Protocol/SmtpParser.cs
+++ b/src/SmtpServer/Protocol/SmtpParser.cs
@@ -39,18 +39,62 @@ namespace SmtpServer.Protocol
         /// <returns>Returns true if a command could be made, false if not.</returns>
         public bool TryMake(ref ReadOnlySequence<byte> buffer, out SmtpCommand command, out SmtpResponse errorResponse)
         {
-            return Make(buffer, TryMakeEhlo, out command, out errorResponse)
-                || Make(buffer, TryMakeHelo, out command, out errorResponse)
-                || Make(buffer, TryMakeMail, out command, out errorResponse)
-                || Make(buffer, TryMakeRcpt, out command, out errorResponse)
-                || Make(buffer, TryMakeData, out command, out errorResponse)
-                || Make(buffer, TryMakeQuit, out command, out errorResponse)
-                || Make(buffer, TryMakeRset, out command, out errorResponse)
-                || Make(buffer, TryMakeNoop, out command, out errorResponse)
-                || Make(buffer, TryMakeStartTls, out command, out errorResponse)
-                || Make(buffer, TryMakeAuth, out command, out errorResponse)
-                || Make(buffer, TryMakeProxy, out command, out errorResponse)
-                || Make(buffer, MakeUnrecognized, out command, out errorResponse);
+            if (Make(buffer, TryMakeEhlo, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeHelo, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeMail, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeRcpt, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeData, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeQuit, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeRset, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeNoop, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeStartTls, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeAuth, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            if (Make(buffer, TryMakeProxy, out command, out errorResponse) || errorResponse != null)
+            {
+                return command != null;
+            }
+
+            return Make(buffer, MakeUnrecognized, out command, out errorResponse);
 
             static bool Make(ReadOnlySequence<byte> buffer, TryMakeDelegate tryMakeDelegate, out SmtpCommand command, out SmtpResponse errorResponse)
             {
@@ -89,6 +133,12 @@ namespace SmtpServer.Protocol
 
             if (reader.TryMake(TryMakeDomain, out var domain))
             {
+                if (TryMakeEnd(ref reader) == false)
+                {
+                    errorResponse = SmtpResponse.SyntaxError;
+                    return false;
+                }
+
                 command = _smtpCommandFactory.CreateHelo(StringUtil.Create(domain));
                 return true;
             }
@@ -98,6 +148,12 @@ namespace SmtpServer.Protocol
             // address literal and there is no harm in accepting it
             if (reader.TryMake(TryMakeAddressLiteral, out var address))
             {
+                if (TryMakeEnd(ref reader) == false)
+                {
+                    errorResponse = SmtpResponse.SyntaxError;
+                    return false;
+                }
+
                 command = _smtpCommandFactory.CreateHelo(StringUtil.Create(address));
                 return true;
             }
@@ -148,12 +204,24 @@ namespace SmtpServer.Protocol
 
             if (reader.TryMake(TryMakeDomain, out var domain))
             {
+                if (TryMakeEnd(ref reader) == false)
+                {
+                    errorResponse = SmtpResponse.SyntaxError;
+                    return false;
+                }
+
                 command = _smtpCommandFactory.CreateEhlo(StringUtil.Create(domain));
                 return true;
             }
 
             if (reader.TryMake(TryMakeAddressLiteral, out var address))
             {
+                if (TryMakeEnd(ref reader) == false)
+                {
+                    errorResponse = SmtpResponse.SyntaxError;
+                    return false;
+                }
+
                 // remove the brackets
                 address = address.Slice(1, address.Length - 2);
 
@@ -223,9 +291,15 @@ namespace SmtpServer.Protocol
             reader.Skip(TokenKind.Space);
 
             // match the optional (ESMTP) parameters
-            if (reader.TryMake(TryMakeMailParameters, out IReadOnlyDictionary<string, string> parameters) == false)
+            IReadOnlyDictionary<string, string> parameters;
+            if (reader.Peek().Kind == TokenKind.None)
             {
                 parameters = new Dictionary<string, string>();
+            }
+            else if (reader.TryMake(TryMakeMailParameters, out parameters) == false)
+            {
+                errorResponse = SmtpResponse.SyntaxError;
+                return false;
             }
 
             command = _smtpCommandFactory.CreateMail(mailbox, parameters);


### PR DESCRIPTION
## Summary

Tightens SMTP parser handling for malformed known commands.

## Root Cause

Some command parsers accepted a valid prefix and returned a command without verifying the command ended cleanly. `MAIL FROM` also treated malformed trailing ESMTP parameters as if no parameters were supplied. At the top-level `TryMake` path, syntax errors from recognized commands could be overwritten by later parser attempts and reported as an unrecognized command.

## Changes

- Preserve syntax errors from recognized command parsers in top-level `TryMake`.
- Require HELO/EHLO parsed domains and address literals to be followed only by command end/whitespace.
- Reject malformed trailing `MAIL FROM` ESMTP parameters instead of silently using an empty parameter dictionary.
- Add regression tests for malformed HELO/EHLO/MAIL inputs and top-level syntax error reporting.

## Validation

- `DOTNET_ROLL_FORWARD=Major dotnet test src/SmtpServer.Tests/SmtpServer.Tests.csproj`
- Result: 126 passed, 1 skipped.

## Jira

- SS-2
