### PR TITLE
SS-4 Add streaming DATA message store path

### DIFF
--- a/src/SmtpServer.Benchmarks/DataStoreBenchmarks.cs
+++ b/src/SmtpServer.Benchmarks/DataStoreBenchmarks.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using MimeKit;
+using SmtpServer.ComponentModel;
+using SmtpServer.Protocol;
+using SmtpServer.Storage;
+using SmtpClient = MailKit.Net.Smtp.SmtpClient;
+
+namespace SmtpServer.Benchmarks
+{
+    [MemoryDiagnoser]
+    [ShortRunJob]
+    public class DataStoreBenchmarks
+    {
+        const int Port = 9026;
+
+        SmtpServer _smtpServer;
+        CancellationTokenSource _smtpServerCancellationTokenSource;
+        SmtpClient _smtpClient;
+        MimeMessage _message;
+
+        public enum StoreMode
+        {
+            BufferedMaterializing,
+            StreamingDrain
+        }
+
+        [Params(StoreMode.BufferedMaterializing, StoreMode.StreamingDrain)]
+        public StoreMode Mode { get; set; }
+
+        [GlobalSetup]
+        public void SmtpServerSetup()
+        {
+            _message = MimeMessage.Load(typeof(DataStoreBenchmarks).Assembly.GetManifestResourceStream("SmtpServer.Benchmarks.Test3.eml"));
+            _smtpServerCancellationTokenSource = new CancellationTokenSource();
+
+            var serviceProvider = new ServiceProvider();
+            serviceProvider.Add(Mode == StoreMode.StreamingDrain
+                ? (IMessageStore)new StreamingDrainMessageStore()
+                : new BufferedMaterializingMessageStore());
+
+            _smtpServer = new SmtpServer(
+                new SmtpServerOptionsBuilder()
+                    .Port(Port, false)
+                    .Build(),
+                serviceProvider);
+
+            _ = _smtpServer.StartAsync(_smtpServerCancellationTokenSource.Token);
+
+            _smtpClient = new SmtpClient();
+            _smtpClient.Connect("localhost", Port);
+        }
+
+        [GlobalCleanup]
+        public Task SmtpServerCleanupAsync()
+        {
+            _smtpClient.Disconnect(true);
+            _smtpClient.Dispose();
+
+            _smtpServerCancellationTokenSource.Cancel();
+            _smtpServerCancellationTokenSource.Dispose();
+
+            return _smtpServer.ShutdownTask;
+        }
+
+        [Benchmark]
+        public void SendMessage()
+        {
+            _smtpClient.Send(_message);
+        }
+
+        sealed class BufferedMaterializingMessageStore : MessageStore
+        {
+            public override Task<SmtpResponse> SaveAsync(ISessionContext context, IMessageTransaction transaction, ReadOnlySequence<byte> buffer, CancellationToken cancellationToken)
+            {
+                _ = buffer.ToArray();
+
+                return Task.FromResult(SmtpResponse.Ok);
+            }
+        }
+
+        sealed class StreamingDrainMessageStore : MessageStore, IStreamingMessageStore
+        {
+            public override Task<SmtpResponse> SaveAsync(ISessionContext context, IMessageTransaction transaction, ReadOnlySequence<byte> buffer, CancellationToken cancellationToken)
+            {
+                throw new NotSupportedException();
+            }
+
+            public async Task<SmtpResponse> SaveAsync(ISessionContext context, IMessageTransaction transaction, PipeReader reader, CancellationToken cancellationToken)
+            {
+                while (true)
+                {
+                    var result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                    var buffer = result.Buffer;
+
+                    reader.AdvanceTo(buffer.End);
+
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+
+                return SmtpResponse.Ok;
+            }
+        }
+    }
+}

--- a/src/SmtpServer.Benchmarks/Program.cs
+++ b/src/SmtpServer.Benchmarks/Program.cs
@@ -8,17 +8,13 @@ namespace SmtpServer.Benchmarks
     {
         public static void Main(string[] args)
         {
-            //var summary = BenchmarkRunner.Run<TokenizerBenchmarks>(
-            //    ManualConfig
-            //        .Create(DefaultConfig.Instance)
-            //        .With(ConfigOptions.DisableOptimizationsValidator));
-
-            //var summary = BenchmarkRunner.Run<ThroughputBenchmarks>();
-
-            var summary = BenchmarkRunner.Run<ThroughputBenchmarks>(
-                ManualConfig
-                    .Create(DefaultConfig.Instance)
-                    .With(ConfigOptions.DisableOptimizationsValidator));
+            BenchmarkSwitcher
+                .FromAssembly(typeof(Program).Assembly)
+                .Run(
+                    args,
+                    ManualConfig
+                        .Create(DefaultConfig.Instance)
+                        .WithOptions(ConfigOptions.DisableOptimizationsValidator));
         }
     }
 }

--- a/src/SmtpServer.Tests/PipeReaderTests.cs
+++ b/src/SmtpServer.Tests/PipeReaderTests.cs
@@ -3,6 +3,7 @@ using System.IO.Pipelines;
 using System.Text;
 using System.Threading.Tasks;
 using SmtpServer.IO;
+using SmtpServer.Protocol;
 using SmtpServer.Text;
 using Xunit;
 
@@ -92,6 +93,67 @@ namespace SmtpServer.Tests
 
             // assert
             Assert.Equal("abcd\r\n.1234", text);
+        }
+
+        [Fact]
+        public async Task CanStreamBlockWithDotStuffingRemoved()
+        {
+            // arrange
+            var reader = CreatePipeReader("abcd\r\n..1234\r\n.\r\n");
+            var writer = new Pipe();
+
+            var maxMessageSizeOptions = new MaxMessageSizeOptions();
+
+            // act
+            await reader.ReadDotBlockAsync(writer.Writer, maxMessageSizeOptions);
+            var text = await ReadAllAsync(writer.Reader);
+
+            // assert
+            Assert.Equal("abcd\r\n.1234", text);
+        }
+
+        [Fact]
+        public async Task CanEnforceMaxMessageSizeWhenStreamingBlock()
+        {
+            // arrange
+            var reader = CreatePipeReader("abcd\r\n1234\r\n.\r\n");
+            var writer = new Pipe();
+
+            var maxMessageSizeOptions = new MaxMessageSizeOptions(MaxMessageSizeHandling.Strict, 5);
+
+            // act
+            var exception = await Assert.ThrowsAsync<SmtpResponseException>(
+                async () => await reader.ReadDotBlockAsync(writer.Writer, maxMessageSizeOptions));
+
+            // assert
+            Assert.True(exception.IsQuitRequested);
+        }
+
+        static async Task<string> ReadAllAsync(PipeReader reader)
+        {
+            using var stream = new MemoryStream();
+
+            while (true)
+            {
+                var result = await reader.ReadAsync();
+                var buffer = result.Buffer;
+
+                foreach (var segment in buffer)
+                {
+                    stream.Write(segment.Span);
+                }
+
+                reader.AdvanceTo(buffer.End);
+
+                if (result.IsCompleted)
+                {
+                    break;
+                }
+            }
+
+            reader.Complete();
+
+            return Encoding.ASCII.GetString(stream.ToArray());
         }
     }
 }

--- a/src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/src/SmtpServer.Tests/SmtpServerTests.cs
@@ -8,8 +8,10 @@ using SmtpServer.Protocol;
 using SmtpServer.Storage;
 using SmtpServer.Tests.Mocks;
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipelines;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
@@ -50,6 +52,21 @@ namespace SmtpServer.Tests
                 Assert.Equal(1, MessageStore.Messages[0].Transaction.To.Count);
                 Assert.Equal("test2@test.com", MessageStore.Messages[0].Transaction.To[0].AsAddress());
             }
+        }
+
+        [Fact]
+        public void CanReceiveMessageUsingStreamingMessageStore()
+        {
+            var streamingMessageStore = new StreamingMockMessageStore();
+
+            using (CreateServer(services => services.Add(streamingMessageStore)))
+            {
+                MailClient.Send(MailClient.Message(from: "test1@test.com", to: "test2@test.com", text: "streamed body"));
+            }
+
+            Assert.True(streamingMessageStore.StreamingSaveCalled);
+            Assert.False(streamingMessageStore.BufferedSaveCalled);
+            Assert.Contains("streamed body", streamingMessageStore.Message);
         }
 
         [Theory]
@@ -655,5 +672,50 @@ namespace SmtpServer.Tests
         /// The cancellation token source for the test.
         /// </summary>
         public CancellationTokenSource CancellationTokenSource { get; }
+
+        sealed class StreamingMockMessageStore : MessageStore, IStreamingMessageStore
+        {
+            public override Task<SmtpResponse> SaveAsync(ISessionContext context, IMessageTransaction transaction, ReadOnlySequence<byte> buffer, CancellationToken cancellationToken)
+            {
+                BufferedSaveCalled = true;
+
+                return Task.FromResult(SmtpResponse.Ok);
+            }
+
+            public async Task<SmtpResponse> SaveAsync(ISessionContext context, IMessageTransaction transaction, PipeReader reader, CancellationToken cancellationToken)
+            {
+                StreamingSaveCalled = true;
+
+                using var stream = new MemoryStream();
+
+                while (true)
+                {
+                    var result = await reader.ReadAsync(cancellationToken);
+                    var buffer = result.Buffer;
+
+                    foreach (var segment in buffer)
+                    {
+                        stream.Write(segment.Span);
+                    }
+
+                    reader.AdvanceTo(buffer.End);
+
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+
+                Message = Encoding.UTF8.GetString(stream.ToArray());
+
+                return SmtpResponse.Ok;
+            }
+
+            public bool BufferedSaveCalled { get; private set; }
+
+            public bool StreamingSaveCalled { get; private set; }
+
+            public string Message { get; private set; }
+        }
     }
 }

--- a/src/SmtpServer/IO/PipeReaderExtensions.cs
+++ b/src/SmtpServer/IO/PipeReaderExtensions.cs
@@ -15,6 +15,7 @@ namespace SmtpServer.IO
         static readonly byte[] CRLF = { 13, 10 };
         static readonly byte[] DotBlock = { 13, 10, 46, 13, 10 };
         static readonly byte[] DotBlockStuffing = { 13, 10, 46, 46 };
+        const int DotBlockTailLength = 4;
 
         /// <summary>
         /// Read from the reader until the sequence is found.
@@ -175,6 +176,140 @@ namespace SmtpServer.IO
                 segments.Append(ref remaining);
                 
                 return segments.Build();
+            }
+        }
+
+        /// <summary>
+        /// Reads a dot block from the reader and writes the unstuffed content to the writer.
+        /// </summary>
+        /// <param name="reader">The reader to read from.</param>
+        /// <param name="writer">The writer to stream the message content to.</param>
+        /// <param name="maxMessageSizeOptions">Handling of MaxMessageSize.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The value that was read from the buffer.</returns>
+        internal static async ValueTask ReadDotBlockAsync(this PipeReader reader, PipeWriter writer, IMaxMessageSizeOptions maxMessageSizeOptions, CancellationToken cancellationToken = default)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            Exception error = null;
+
+            try
+            {
+                await ReadDotBlockAsync(reader, writer, maxMessageSizeOptions, cancellationToken, DotBlockTailLength).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                error = exception;
+                throw;
+            }
+            finally
+            {
+                writer.Complete(error);
+            }
+        }
+
+        static async ValueTask ReadDotBlockAsync(PipeReader reader, PipeWriter writer, IMaxMessageSizeOptions maxMessageSizeOptions, CancellationToken cancellationToken, int tailLength)
+        {
+            long consumedLength = 0;
+
+            while (true)
+            {
+                var read = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+                var buffer = read.Buffer;
+
+                if (buffer.IsEmpty && read.IsCompleted)
+                {
+                    return;
+                }
+
+                var head = buffer.GetPosition(0);
+                if (buffer.TryFind(DotBlock, ref head, out var tail))
+                {
+                    var body = buffer.Slice(buffer.Start, head);
+
+                    EnsureMessageSize(maxMessageSizeOptions, consumedLength + body.Length);
+
+                    await WriteUnstuffedAsync(writer, body, cancellationToken).ConfigureAwait(false);
+
+                    reader.AdvanceTo(tail);
+                    return;
+                }
+
+                if (read.IsCompleted)
+                {
+                    reader.AdvanceTo(buffer.End);
+                    return;
+                }
+
+                if (buffer.Length > tailLength)
+                {
+                    var safeLength = buffer.Length - tailLength;
+                    var safeBuffer = buffer.Slice(0, safeLength);
+
+                    EnsureMessageSize(maxMessageSizeOptions, consumedLength + safeBuffer.Length);
+
+                    await WriteUnstuffedAsync(writer, safeBuffer, cancellationToken).ConfigureAwait(false);
+
+                    consumedLength += safeBuffer.Length;
+
+                    reader.AdvanceTo(buffer.GetPosition(safeLength), buffer.End);
+                    continue;
+                }
+
+                reader.AdvanceTo(buffer.Start, buffer.End);
+            }
+        }
+
+        static void EnsureMessageSize(IMaxMessageSizeOptions maxMessageSizeOptions, long length)
+        {
+            if (maxMessageSizeOptions.Handling == MaxMessageSizeHandling.Strict && length > maxMessageSizeOptions.Length)
+            {
+                throw new SmtpResponseException(SmtpResponse.MaxMessageSizeExceeded, true);
+            }
+        }
+
+        static async ValueTask WriteUnstuffedAsync(PipeWriter writer, ReadOnlySequence<byte> buffer, CancellationToken cancellationToken)
+        {
+            var head = buffer.GetPosition(0);
+            var start = head;
+
+            while (buffer.TryFind(DotBlockStuffing, ref head, out var tail))
+            {
+                var slice = buffer.Slice(start, buffer.GetPosition(3, head));
+
+                Write(writer, slice);
+
+                start = tail;
+                head = tail;
+            }
+
+            Write(writer, buffer.Slice(start));
+
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        static void Write(PipeWriter writer, ReadOnlySequence<byte> buffer)
+        {
+            var position = buffer.GetPosition(0);
+
+            while (buffer.TryGet(ref position, out var memory))
+            {
+                if (memory.Length == 0)
+                {
+                    continue;
+                }
+
+                var span = writer.GetSpan(memory.Length);
+                memory.Span.CopyTo(span);
+                writer.Advance(memory.Length);
             }
         }
     }

--- a/src/SmtpServer/Protocol/DataCommand.cs
+++ b/src/SmtpServer/Protocol/DataCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.ComponentModel;
@@ -45,16 +46,9 @@ namespace SmtpServer.Protocol
             {
                 using var container = new DisposableContainer<IMessageStore>(messageStore);
 
-                SmtpResponse response = null;
-
-                await context.Pipe.Input.ReadDotBlockAsync(
-                    async buffer =>
-                    {
-                        // ReSharper disable once AccessToDisposedClosure
-                        response = await container.Instance.SaveAsync(context, context.Transaction, buffer, cancellationToken).ConfigureAwait(false);
-                    },
-                    context.ServerOptions.MaxMessageSizeOptions,
-                    cancellationToken).ConfigureAwait(false);
+                var response = container.Instance is IStreamingMessageStore streamingMessageStore
+                    ? await SaveAsync(streamingMessageStore, context, cancellationToken).ConfigureAwait(false)
+                    : await SaveAsync(container.Instance, context, cancellationToken).ConfigureAwait(false);
                     
                 await context.Pipe.Output.WriteReplyAsync(response, cancellationToken).ConfigureAwait(false);
             }
@@ -69,6 +63,40 @@ namespace SmtpServer.Protocol
             }
 
             return true;
+        }
+
+        static async Task<SmtpResponse> SaveAsync(IMessageStore messageStore, SmtpSessionContext context, CancellationToken cancellationToken)
+        {
+            SmtpResponse response = null;
+
+            await context.Pipe.Input.ReadDotBlockAsync(
+                async buffer =>
+                {
+                    response = await messageStore.SaveAsync(context, context.Transaction, buffer, cancellationToken).ConfigureAwait(false);
+                },
+                context.ServerOptions.MaxMessageSizeOptions,
+                cancellationToken).ConfigureAwait(false);
+
+            return response;
+        }
+
+        static async Task<SmtpResponse> SaveAsync(IStreamingMessageStore messageStore, SmtpSessionContext context, CancellationToken cancellationToken)
+        {
+            var pipe = new Pipe();
+
+            try
+            {
+                var readTask = context.Pipe.Input.ReadDotBlockAsync(pipe.Writer, context.ServerOptions.MaxMessageSizeOptions, cancellationToken).AsTask();
+                var saveTask = messageStore.SaveAsync(context, context.Transaction, pipe.Reader, cancellationToken);
+
+                await readTask.ConfigureAwait(false);
+
+                return await saveTask.ConfigureAwait(false);
+            }
+            finally
+            {
+                pipe.Reader.Complete();
+            }
         }
     }
 }

--- a/src/SmtpServer/Storage/IStreamingMessageStore.cs
+++ b/src/SmtpServer/Storage/IStreamingMessageStore.cs
@@ -1,0 +1,23 @@
+﻿using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using SmtpServer.Protocol;
+
+namespace SmtpServer.Storage
+{
+    /// <summary>
+    /// Streaming Message Store Interface
+    /// </summary>
+    public interface IStreamingMessageStore : IMessageStore
+    {
+        /// <summary>
+        /// Save the given message to the underlying storage system.
+        /// </summary>
+        /// <param name="context">The session level context.</param>
+        /// <param name="transaction">The SMTP message transaction to store.</param>
+        /// <param name="reader">The reader that streams the message content.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The response code to return that indicates the result of the message being saved.</returns>
+        Task<SmtpResponse> SaveAsync(ISessionContext context, IMessageTransaction transaction, PipeReader reader, CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in streaming message store path for SMTP DATA handling.

## Why

The existing DATA flow reads the complete dot-block into a `ReadOnlySequence<byte>` before invoking message storage. That preserves compatibility but forces full-message buffering before custom storage can process content. This change lets storage implementations opt into streaming while leaving existing `IMessageStore` implementations untouched.

## Changes

- Add `IStreamingMessageStore`, extending `IMessageStore` with a `PipeReader`-based save method.
- Update `DataCommand` to stream DATA content to stores that implement `IStreamingMessageStore`.
- Keep the existing buffered `IMessageStore.SaveAsync(... ReadOnlySequence<byte> ...)` path for all current consumers.
- Add a streaming dot-block pipe helper that removes dot-stuffing while preserving strict max-message-size enforcement.
- Add pipe-level tests and a server-level test proving streaming stores are selected.

## Validation

- `DOTNET_ROLL_FORWARD=Major dotnet test src/SmtpServer.Tests/SmtpServer.Tests.csproj`
- Result: 120 passed, 1 skipped.

## Notes

- This is an additive API; existing message stores do not need to change.
- BenchmarkDotNet benchmarks were not run; validation focused on behavior and compatibility tests.

## Jira

- SS-4
