### PR TITLE
SS-6 Wire NetworkBufferSize into connection pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added: Configuration option to define the maximum allowed message size.
 - Added: Support for custom SMTP greeting messages.
+- Fixed: NetworkBufferSize now controls the stream read buffer used by the SMTP connection pipe.
 - Improved: Optimized protection against excessively long text segments to enhance stability and performance.
 
 ```cs

--- a/src/SmtpServer.Tests/SecurableDuplexPipeTests.cs
+++ b/src/SmtpServer.Tests/SecurableDuplexPipeTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SmtpServer.IO;
+using Xunit;
+
+namespace SmtpServer.Tests
+{
+    public class SecurableDuplexPipeTests
+    {
+        [Fact]
+        public async Task CanUseConfiguredNetworkBufferSize()
+        {
+            // arrange
+            var stream = new RecordingReadStream();
+            using var pipe = new SecurableDuplexPipe(stream, 4096, () => { });
+
+            // act
+            var result = await pipe.Input.ReadAsync();
+            pipe.Input.AdvanceTo(result.Buffer.End);
+
+            // assert
+            Assert.Equal(4096, stream.LastReadBufferSize);
+        }
+
+        sealed class RecordingReadStream : Stream
+        {
+            public int LastReadBufferSize { get; private set; }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => 0;
+
+            public override long Position
+            {
+                get => 0;
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                LastReadBufferSize = count;
+                return 0;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                LastReadBufferSize = count;
+                return Task.FromResult(0);
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                LastReadBufferSize = buffer.Length;
+                return new ValueTask<int>(0);
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/src/SmtpServer.Tests/SmtpServerTests.cs
@@ -506,6 +506,14 @@ namespace SmtpServer.Tests
             Assert.True(stopped);
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void CanNotConfigureInvalidNetworkBufferSize(int value)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SmtpServerOptionsBuilder().NetworkBufferSize(value));
+        }
+
         public static X509Certificate2 CreateSelfSignedCertificate(string subjectName)
         {
             var validityPeriodInYears = 1;

--- a/src/SmtpServer/IO/SecurableDuplexPipe.cs
+++ b/src/SmtpServer/IO/SecurableDuplexPipe.cs
@@ -12,6 +12,7 @@ namespace SmtpServer.IO
     internal sealed class SecurableDuplexPipe : ISecurableDuplexPipe
     {
         readonly Action _disposeAction;
+        readonly int _networkBufferSize;
         Stream _stream;
         bool _disposed;
 
@@ -19,13 +20,15 @@ namespace SmtpServer.IO
         /// Constructor.
         /// </summary>
         /// <param name="stream">The stream that the pipe is reading and writing to.</param>
+        /// <param name="networkBufferSize">The size of the buffer to use when reading from the stream.</param>
         /// <param name="disposeAction">The action to execute when the stream has been disposed.</param>
-        internal SecurableDuplexPipe(Stream stream, Action disposeAction)
+        internal SecurableDuplexPipe(Stream stream, int networkBufferSize, Action disposeAction)
         {
             _stream = stream;
+            _networkBufferSize = networkBufferSize;
             _disposeAction = disposeAction;
 
-            Input = PipeReader.Create(_stream);
+            Input = PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: networkBufferSize));
             Output = PipeWriter.Create(_stream);
         }
 
@@ -54,7 +57,7 @@ namespace SmtpServer.IO
 
             _stream = sslStream;
 
-            Input = PipeReader.Create(_stream);
+            Input = PipeReader.Create(_stream, new StreamPipeReaderOptions(bufferSize: _networkBufferSize));
             Output = PipeWriter.Create(_stream);
         }
 

--- a/src/SmtpServer/Net/EndpointListener.cs
+++ b/src/SmtpServer/Net/EndpointListener.cs
@@ -51,7 +51,7 @@ namespace SmtpServer.Net
 
             var stream = tcpClient.GetStream();
 
-            return new SecurableDuplexPipe(stream, () =>
+            return new SecurableDuplexPipe(stream, context.ServerOptions.NetworkBufferSize, () =>
             {
                 try
                 {

--- a/src/SmtpServer/SmtpServerOptionsBuilder.cs
+++ b/src/SmtpServer/SmtpServerOptionsBuilder.cs
@@ -141,6 +141,11 @@ namespace SmtpServer
         /// <returns>An OptionsBuilder to continue building on.</returns>
         public SmtpServerOptionsBuilder NetworkBufferSize(int value)
         {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "The network buffer size must be greater than zero.");
+            }
+
             _setters.Add(options => options.NetworkBufferSize = value);
 
             return this;


### PR DESCRIPTION
## Summary
- Wire `NetworkBufferSize` into the `PipeReader` created for each SMTP connection stream.
- Preserve the configured buffer size after STARTTLS swaps the underlying stream.
- Validate `NetworkBufferSize` values so non-positive sizes fail early.
- Add tests proving the configured size is observable at the pipe read layer.
- Document the fix in the changelog.

## Verification
- `DOTNET_ROLL_FORWARD=Major dotnet test src/SmtpServer.Tests/SmtpServer.Tests.csproj`
  - Passed: 120, Skipped: 1

## Notes
- The option is kept as public API and now matches its existing XML documentation: it controls the size of the buffer used when reading from the network stream.
- Existing warnings remain unrelated: MailKit NU1902, AuthCommand XML doc warning, and existing xUnit analyzer warnings.
