### PR TITLE
SS-7 Reduce AUTH and EHLO allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added: Configuration option to define the maximum allowed message size.
 - Added: Support for custom SMTP greeting messages.
+- Improved: Reduced allocations in EHLO response generation and AUTH credential parsing.
 - Improved: Optimized protection against excessively long text segments to enhance stability and performance.
 
 ```cs

--- a/src/SmtpServer.Benchmarks/AuthEhloBenchmarks.cs
+++ b/src/SmtpServer.Benchmarks/AuthEhloBenchmarks.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using SmtpServer.Authentication;
+using SmtpServer.ComponentModel;
+using SmtpServer.IO;
+using SmtpServer.Protocol;
+
+namespace SmtpServer.Benchmarks
+{
+    [MemoryDiagnoser]
+    [ShortRunJob]
+    public class AuthEhloBenchmarks
+    {
+        readonly EhloCommand _ehloCommand = new EhloCommand("example.com");
+        readonly AuthCommand _authPlainCommand = new AuthCommand(AuthenticationMethod.Plain, "AHVzZXIAcGFzc3dvcmQ=");
+        readonly AuthCommand _invalidAuthPlainCommand = new AuthCommand(AuthenticationMethod.Plain, "not-base64");
+
+        MemoryStream _ehloStream;
+        SmtpSessionContext _ehloContext;
+        MemoryStream _authStream;
+        SmtpSessionContext _authContext;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _ehloStream = new MemoryStream();
+            _ehloContext = CreateContext(_ehloStream, addAuthenticator: false);
+
+            _authStream = new MemoryStream();
+            _authContext = CreateContext(_authStream, addAuthenticator: true);
+        }
+
+        [Benchmark]
+        public Task Ehlo()
+        {
+            Reset(_ehloStream);
+
+            return _ehloCommand.ExecuteAsync(_ehloContext, CancellationToken.None);
+        }
+
+        [Benchmark]
+        public Task AuthPlain()
+        {
+            Reset(_authStream);
+
+            return _authPlainCommand.ExecuteAsync(_authContext, CancellationToken.None);
+        }
+
+        [Benchmark]
+        public Task InvalidAuthPlain()
+        {
+            Reset(_authStream);
+
+            return _invalidAuthPlainCommand.ExecuteAsync(_authContext, CancellationToken.None);
+        }
+
+        static SmtpSessionContext CreateContext(Stream stream, bool addAuthenticator)
+        {
+            var endpointDefinition = new EndpointDefinitionBuilder()
+                .AllowUnsecureAuthentication()
+                .Build();
+            var options = new SmtpServerOptionsBuilder()
+                .ServerName("localhost")
+                .Endpoint(endpointDefinition)
+                .Build();
+            var serviceProvider = new ServiceProvider();
+
+            if (addAuthenticator)
+            {
+                serviceProvider.Add(new DelegatingUserAuthenticator((user, password) => true));
+            }
+
+            var context = new SmtpSessionContext(serviceProvider, options, endpointDefinition)
+            {
+                Pipe = new SecurableDuplexPipe(stream, () => { })
+            };
+
+            return context;
+        }
+
+        static void Reset(MemoryStream stream)
+        {
+            stream.Position = 0;
+            stream.SetLength(0);
+        }
+    }
+}

--- a/src/SmtpServer.Benchmarks/Program.cs
+++ b/src/SmtpServer.Benchmarks/Program.cs
@@ -8,17 +8,13 @@ namespace SmtpServer.Benchmarks
     {
         public static void Main(string[] args)
         {
-            //var summary = BenchmarkRunner.Run<TokenizerBenchmarks>(
-            //    ManualConfig
-            //        .Create(DefaultConfig.Instance)
-            //        .With(ConfigOptions.DisableOptimizationsValidator));
-
-            //var summary = BenchmarkRunner.Run<ThroughputBenchmarks>();
-
-            var summary = BenchmarkRunner.Run<ThroughputBenchmarks>(
-                ManualConfig
-                    .Create(DefaultConfig.Instance)
-                    .With(ConfigOptions.DisableOptimizationsValidator));
+            BenchmarkSwitcher
+                .FromAssembly(typeof(Program).Assembly)
+                .Run(
+                    args,
+                    ManualConfig
+                        .Create(DefaultConfig.Instance)
+                        .WithOptions(ConfigOptions.DisableOptimizationsValidator));
         }
     }
 }

--- a/src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/src/SmtpServer.Tests/SmtpServerTests.cs
@@ -126,6 +126,72 @@ namespace SmtpServer.Tests
             }
         }
 
+        [Theory]
+        [InlineData("AUTH PLAIN not-base64")]
+        [InlineData("AUTH LOGIN not-base64")]
+        public async Task CanFailInvalidBase64AuthenticationWithoutFaulting(string command)
+        {
+            var userAuthenticator = new DelegatingUserAuthenticator((user, password) => true);
+
+            using (CreateServer(endpoint => endpoint.AllowUnsecureAuthentication(), services => services.Add(userAuthenticator)))
+            using (var rawSmtpClient = new RawSmtpClient("127.0.0.1", 9025))
+            {
+                Assert.True(await rawSmtpClient.ConnectAsync());
+
+                var ehloResponse = await rawSmtpClient.SendCommandAsync("EHLO example.com");
+                Assert.StartsWith("250-", ehloResponse);
+
+                var response = await rawSmtpClient.SendCommandAsync(command);
+                Assert.StartsWith("535 authentication failed", response);
+
+                response = await rawSmtpClient.SendCommandAsync("NOOP");
+                Assert.StartsWith("250 Ok", response);
+            }
+        }
+
+        [Fact]
+        public async Task CanFailInvalidBase64AuthenticationContinuationWithoutFaulting()
+        {
+            var userAuthenticator = new DelegatingUserAuthenticator((user, password) => true);
+
+            using (CreateServer(endpoint => endpoint.AllowUnsecureAuthentication(), services => services.Add(userAuthenticator)))
+            using (var rawSmtpClient = new RawSmtpClient("127.0.0.1", 9025))
+            {
+                Assert.True(await rawSmtpClient.ConnectAsync());
+
+                var ehloResponse = await rawSmtpClient.SendCommandAsync("EHLO example.com");
+                Assert.StartsWith("250-", ehloResponse);
+
+                var response = await rawSmtpClient.SendCommandAsync("AUTH LOGIN");
+                Assert.StartsWith("334 VXNlcm5hbWU6", response);
+
+                response = await rawSmtpClient.SendCommandAsync("not-base64");
+                Assert.StartsWith("535 authentication failed", response);
+
+                response = await rawSmtpClient.SendCommandAsync("NOOP");
+                Assert.StartsWith("250 Ok", response);
+            }
+        }
+
+        [Fact]
+        public async Task CanReturnStableEhloResponse()
+        {
+            using (CreateServer())
+            using (var rawSmtpClient = new RawSmtpClient("127.0.0.1", 9025))
+            {
+                Assert.True(await rawSmtpClient.ConnectAsync());
+
+                var response = await rawSmtpClient.SendCommandAsync("EHLO example.com");
+
+                Assert.Equal(
+                    "250-localhost Hello example.com, haven't we met before?\r\n" +
+                    "250-PIPELINING\r\n" +
+                    "250-8BITMIME\r\n" +
+                    "250 SMTPUTF8\r\n",
+                    response);
+            }
+        }
+
         [Fact]
         public void CanReceiveBccInMessageTransaction()
         {

--- a/src/SmtpServer/Protocol/AuthCommand.cs
+++ b/src/SmtpServer/Protocol/AuthCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO.Pipelines;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.Authentication;
@@ -111,7 +110,6 @@ namespace SmtpServer.Protocol
 
             if (TryExtractFromBase64(authentication) == false)
             {
-                await context.Pipe.Output.WriteReplyAsync(SmtpResponse.AuthenticationFailed, cancellationToken).ConfigureAwait(false);
                 return false;
             }
 
@@ -125,15 +123,36 @@ namespace SmtpServer.Protocol
         /// <returns>true if the user name and password were extracted from the base64 encoded string, false if not.</returns>
         bool TryExtractFromBase64(string base64)
         {
-            var match = Regex.Match(Encoding.UTF8.GetString(Convert.FromBase64String(base64)), "\x0000(?<user>.*)\x0000(?<password>.*)");
-
-            if (match.Success == false)
+            if (TryDecodeBase64(base64, out var buffer, out var bytesWritten) == false)
             {
                 return false;
             }
 
-            _user = match.Groups["user"].Value;
-            _password = match.Groups["password"].Value;
+            try
+            {
+                var decoded = new ReadOnlySpan<byte>(buffer, 0, bytesWritten);
+
+                var userStart = decoded.IndexOf((byte)0);
+                if (userStart < 0)
+                {
+                    return false;
+                }
+
+                var passwordStart = decoded.Slice(userStart + 1).IndexOf((byte)0);
+                if (passwordStart < 0)
+                {
+                    return false;
+                }
+
+                passwordStart += userStart + 1;
+
+                _user = Encoding.UTF8.GetString(buffer, userStart + 1, passwordStart - userStart - 1);
+                _password = Encoding.UTF8.GetString(buffer, passwordStart + 1, bytesWritten - passwordStart - 1);
+            }
+            finally
+            {
+                Array.Clear(buffer, 0, bytesWritten);
+            }
 
             return true;
         }
@@ -148,7 +167,10 @@ namespace SmtpServer.Protocol
         {
             if (string.IsNullOrWhiteSpace(Parameter) == false)
             {
-                _user = Encoding.UTF8.GetString(Convert.FromBase64String(Parameter));
+                if (TryDecodeBase64String(Parameter, out _user) == false)
+                {
+                    return false;
+                }
             }
             else
             {
@@ -156,12 +178,20 @@ namespace SmtpServer.Protocol
                 await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.ContinueWithAuth, "VXNlcm5hbWU6"), cancellationToken).ConfigureAwait(false);
 
                 _user = await ReadBase64EncodedLineAsync(context.Pipe.Input, context.ServerOptions.MaxMessageSizeOptions, cancellationToken).ConfigureAwait(false);
+                if (_user == null)
+                {
+                    return false;
+                }
             }
 
             //Password = UGFzc3dvcmQ6 (base64)
             await context.Pipe.Output.WriteReplyAsync(new SmtpResponse(SmtpReplyCode.ContinueWithAuth, "UGFzc3dvcmQ6"), cancellationToken).ConfigureAwait(false);
 
             _password = await ReadBase64EncodedLineAsync(context.Pipe.Input, context.ServerOptions.MaxMessageSizeOptions, cancellationToken).ConfigureAwait(false);
+            if (_password == null)
+            {
+                return false;
+            }
 
             return true;
         }
@@ -170,13 +200,58 @@ namespace SmtpServer.Protocol
         /// Read a Base64 encoded line.
         /// </summary>
         /// <param name="reader">The pipe to read from.</param>
+        /// <param name="maxMessageSizeOptions">The maximum message size options.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The decoded Base64 string.</returns>
+        /// <returns>The decoded Base64 string, or null when the line is invalid.</returns>
         static async Task<string> ReadBase64EncodedLineAsync(PipeReader reader, IMaxMessageSizeOptions maxMessageSizeOptions, CancellationToken cancellationToken)
         {
             var text = await reader.ReadLineAsync(maxMessageSizeOptions, cancellationToken);
 
-            return text == null ? string.Empty : Encoding.UTF8.GetString(Convert.FromBase64String(text));
+            return TryDecodeBase64String(text, out var value) ? value : null;
+        }
+
+        static bool TryDecodeBase64String(string text, out string value)
+        {
+            value = null;
+
+            if (TryDecodeBase64(text, out var buffer, out var bytesWritten) == false)
+            {
+                return false;
+            }
+
+            try
+            {
+                value = Encoding.UTF8.GetString(buffer, 0, bytesWritten);
+            }
+            finally
+            {
+                Array.Clear(buffer, 0, bytesWritten);
+            }
+
+            return true;
+        }
+
+        static bool TryDecodeBase64(string text, out byte[] buffer, out int bytesWritten)
+        {
+            buffer = null;
+            bytesWritten = 0;
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            var maxByteCount = text.Length;
+            buffer = new byte[maxByteCount];
+
+            if (Convert.TryFromBase64String(text, buffer, out bytesWritten) == false)
+            {
+                Array.Clear(buffer, 0, buffer.Length);
+                buffer = null;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/SmtpServer/Protocol/EhloCommand.cs
+++ b/src/SmtpServer/Protocol/EhloCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.Authentication;
@@ -35,14 +34,28 @@ namespace SmtpServer.Protocol
         /// if the current state is to be maintained.</returns>
         internal override async Task<bool> ExecuteAsync(SmtpSessionContext context, CancellationToken cancellationToken)
         {
-            var output = new[] { GetGreeting(context) }.Union(GetExtensions(context)).ToArray();
+            var greeting = GetGreeting(context);
 
-            for (var i = 0; i < output.Length - 1; i++)
+            using (var extensions = GetExtensions(context).GetEnumerator())
             {
-                context.Pipe.Output.WriteLine($"250-{output[i]}");
-            }
+                if (extensions.MoveNext() == false)
+                {
+                    context.Pipe.Output.WriteLine($"250 {greeting}");
+                }
+                else
+                {
+                    context.Pipe.Output.WriteLine($"250-{greeting}");
 
-            context.Pipe.Output.WriteLine($"250 {output[output.Length - 1]}");
+                    var extension = extensions.Current;
+                    while (extensions.MoveNext())
+                    {
+                        context.Pipe.Output.WriteLine($"250-{extension}");
+                        extension = extensions.Current;
+                    }
+
+                    context.Pipe.Output.WriteLine($"250 {extension}");
+                }
+            }
 
             await context.Pipe.Output.FlushAsync(cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- Stream EHLO response lines without materializing an intermediate array.
- Replace AUTH PLAIN regex parsing with explicit NUL-delimited parsing over decoded bytes.
- Use non-throwing base64 decode paths for AUTH PLAIN and LOGIN invalid inputs.
- Emit a single authentication failure response for invalid AUTH PLAIN input.
- Add raw SMTP tests for invalid AUTH base64 and stable EHLO output.
- Add Auth/EHLO benchmarks and enable filtered benchmark runs.

## Verification
- `DOTNET_ROLL_FORWARD=Major dotnet test src/SmtpServer.Tests/SmtpServer.Tests.csproj --no-restore`
  - Passed: 121, Skipped: 1
- `DOTNET_ROLL_FORWARD=Major dotnet build src/SmtpServer.Benchmarks/SmtpServer.Benchmarks.csproj`
  - Passed with existing MailKit NU1902 advisory warning
- `DOTNET_ROLL_FORWARD=Major dotnet run -c Release --project src/SmtpServer.Benchmarks/SmtpServer.Benchmarks.csproj -- --filter *AuthEhloBenchmarks*`

## Benchmark Notes
ShortRun on .NET 9.0.17:
- EHLO: 311.9 ns, 528 B allocated
- AUTH PLAIN: 327.8 ns, 248 B allocated
- Invalid AUTH PLAIN: 239.0 ns, 136 B allocated
