### PR TITLE
SS-8 Add DSN envelope parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added: Configuration option to define the maximum allowed message size.
 - Added: Support for custom SMTP greeting messages.
+- Added: DSN envelope parameter support for MAIL and RCPT commands.
 - Improved: Optimized protection against excessively long text segments to enhance stability and performance.
 
 ```cs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ SmtpServer currently supports the following extensions:
 - PIPELINING
 - 8BITMIME
 - SMTPUTF8
+- DSN
 - AUTH PLAIN LOGIN
+
+DSN support parses and exposes `RET`, `ENVID`, `NOTIFY`, and `ORCPT` envelope parameters. Applications remain responsible for generating and delivering delivery status notifications from their message store or mailbox filter code.
 
 ## Installation
 

--- a/src/SmtpServer.Tests/SmtpParserTests.cs
+++ b/src/SmtpServer.Tests/SmtpParserTests.cs
@@ -174,6 +174,23 @@ namespace SmtpServer.Tests
         }
 
         [Fact]
+        public void CanMakeMailWithDsnParameters()
+        {
+            // arrange
+            var reader = CreateReader("MAIL FROM:<sender@example.com> ret=FULL ENVID=abc123");
+
+            // act
+            var result = Parser.TryMakeMail(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.True(result);
+            Assert.Null(errorResponse);
+            var mailCommand = Assert.IsType<MailCommand>(command);
+            Assert.Equal("FULL", mailCommand.Parameters["RET"]);
+            Assert.Equal("abc123", mailCommand.Parameters["envid"]);
+        }
+
+        [Fact]
         public void CanMakeMailWithNoAddress()
         {
             // arrange
@@ -242,6 +259,25 @@ namespace SmtpServer.Tests
             Assert.True(command is RcptCommand);
             Assert.Equal(user, ((RcptCommand)command).Address.User);
             Assert.Equal(host, ((RcptCommand)command).Address.Host);
+        }
+
+        [Fact]
+        public void CanMakeRcptWithDsnParameters()
+        {
+            // arrange
+            var reader = CreateReader("RCPT TO:<recipient@example.com> notify=SUCCESS,FAILURE ORCPT=rfc822;original@example.com");
+
+            // act
+            var result = Parser.TryMakeRcpt(ref reader, out var command, out var errorResponse);
+
+            // assert
+            Assert.True(result);
+            Assert.Null(errorResponse);
+            var rcptCommand = Assert.IsType<RcptCommand>(command);
+            Assert.Equal("recipient", rcptCommand.Address.User);
+            Assert.Equal("example.com", rcptCommand.Address.Host);
+            Assert.Equal("SUCCESS,FAILURE", rcptCommand.Parameters["NOTIFY"]);
+            Assert.Equal("rfc822;original@example.com", rcptCommand.Parameters["orcpt"]);
         }
 
         [Theory]

--- a/src/SmtpServer.Tests/SmtpServerTests.cs
+++ b/src/SmtpServer.Tests/SmtpServerTests.cs
@@ -8,6 +8,7 @@ using SmtpServer.Protocol;
 using SmtpServer.Storage;
 using SmtpServer.Tests.Mocks;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -142,6 +143,52 @@ namespace SmtpServer.Tests
                 Assert.Equal("test3@test.com", MessageStore.Messages[0].Transaction.To[1].AsAddress());
                 Assert.Equal("test4@test.com", MessageStore.Messages[0].Transaction.To[2].AsAddress());
             }
+        }
+
+        [Fact]
+        public async Task CanReceiveDsnEnvelopeParameters()
+        {
+            IReadOnlyDictionary<string, string> filterParameters = null;
+            var mailboxFilter = new ParameterizedMailboxFilter((context, to, from, parameters, cancellationToken) =>
+            {
+                filterParameters = parameters;
+                return Task.FromResult(true);
+            });
+
+            using (CreateServer(services => services.Add(mailboxFilter)))
+            using (var rawSmtpClient = new RawSmtpClient("127.0.0.1", 9025))
+            {
+                Assert.True(await rawSmtpClient.ConnectAsync());
+
+                var response = await rawSmtpClient.SendCommandAsync("EHLO example.com");
+                Assert.Contains("DSN", response);
+
+                response = await rawSmtpClient.SendCommandAsync("MAIL FROM:<sender@example.com> RET=FULL ENVID=abc123");
+                Assert.StartsWith("250 Ok", response);
+
+                response = await rawSmtpClient.SendCommandAsync("RCPT TO:<recipient@example.com> notify=SUCCESS,FAILURE orcpt=rfc822;original@example.com");
+                Assert.StartsWith("250 Ok", response);
+
+                response = await rawSmtpClient.SendCommandAsync("DATA");
+                Assert.StartsWith("354", response);
+
+                response = await rawSmtpClient.SendCommandAsync("From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: DSN\r\n\r\nbody\r\n.");
+                Assert.StartsWith("250 Ok", response);
+            }
+
+            Assert.Single(MessageStore.Messages);
+            var transaction = MessageStore.Messages[0].Transaction;
+            Assert.Equal("FULL", transaction.Parameters["ret"]);
+            Assert.Equal("abc123", transaction.Parameters["ENVID"]);
+
+            var recipient = Assert.Single(transaction.GetRecipients());
+            Assert.Equal("recipient@example.com", recipient.Address.AsAddress());
+            Assert.Equal("SUCCESS,FAILURE", recipient.Parameters["NOTIFY"]);
+            Assert.Equal("rfc822;original@example.com", recipient.Parameters["ORCPT"]);
+
+            Assert.NotNull(filterParameters);
+            Assert.Equal("SUCCESS,FAILURE", filterParameters["notify"]);
+            Assert.Equal("rfc822;original@example.com", filterParameters["orcpt"]);
         }
 
         [Fact(Skip = "Command timeout wont work properly until https://github.com/dotnet/corefx/issues/15033")]
@@ -655,5 +702,26 @@ namespace SmtpServer.Tests
         /// The cancellation token source for the test.
         /// </summary>
         public CancellationTokenSource CancellationTokenSource { get; }
+
+        sealed class ParameterizedMailboxFilter : MailboxFilter
+        {
+            readonly Func<ISessionContext, IMailbox, IMailbox, IReadOnlyDictionary<string, string>, CancellationToken, Task<bool>> _canDeliverDelegate;
+
+            public ParameterizedMailboxFilter(
+                Func<ISessionContext, IMailbox, IMailbox, IReadOnlyDictionary<string, string>, CancellationToken, Task<bool>> canDeliverDelegate)
+            {
+                _canDeliverDelegate = canDeliverDelegate;
+            }
+
+            public override Task<bool> CanDeliverToAsync(
+                ISessionContext context,
+                IMailbox to,
+                IMailbox @from,
+                IReadOnlyDictionary<string, string> parameters,
+                CancellationToken cancellationToken)
+            {
+                return _canDeliverDelegate(context, to, @from, parameters, cancellationToken);
+            }
+        }
     }
 }

--- a/src/SmtpServer/IMessageRecipient.cs
+++ b/src/SmtpServer/IMessageRecipient.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using SmtpServer.Mail;
+
+namespace SmtpServer
+{
+    /// <summary>
+    /// Message recipient with the parameters supplied on the RCPT command.
+    /// </summary>
+    public interface IMessageRecipient
+    {
+        /// <summary>
+        /// Gets the recipient mailbox address.
+        /// </summary>
+        IMailbox Address { get; }
+
+        /// <summary>
+        /// Gets the parameters that were supplied for the recipient.
+        /// </summary>
+        IReadOnlyDictionary<string, string> Parameters { get; }
+    }
+}

--- a/src/SmtpServer/IParameterizedMessageTransaction.cs
+++ b/src/SmtpServer/IParameterizedMessageTransaction.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace SmtpServer
+{
+    /// <summary>
+    /// Optional message transaction interface for recipient-specific parameters.
+    /// </summary>
+    public interface IParameterizedMessageTransaction
+    {
+        /// <summary>
+        /// Gets the accepted recipients and their RCPT command parameters.
+        /// </summary>
+        IReadOnlyList<IMessageRecipient> Recipients { get; }
+    }
+}

--- a/src/SmtpServer/MessageTransactionExtensions.cs
+++ b/src/SmtpServer/MessageTransactionExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace SmtpServer
+{
+    /// <summary>
+    /// Extension methods for message transactions.
+    /// </summary>
+    public static class MessageTransactionExtensions
+    {
+        /// <summary>
+        /// Gets recipient-specific parameters when the transaction provides them.
+        /// </summary>
+        /// <param name="transaction">The message transaction.</param>
+        /// <returns>The accepted recipients and their RCPT command parameters.</returns>
+        public static IReadOnlyList<IMessageRecipient> GetRecipients(this IMessageTransaction transaction)
+        {
+            if (transaction is IParameterizedMessageTransaction parameterized)
+            {
+                return parameterized.Recipients;
+            }
+
+            return Array.Empty<IMessageRecipient>();
+        }
+    }
+}

--- a/src/SmtpServer/Protocol/EhloCommand.cs
+++ b/src/SmtpServer/Protocol/EhloCommand.cs
@@ -69,6 +69,7 @@ namespace SmtpServer.Protocol
             yield return "PIPELINING";
             yield return "8BITMIME";
             yield return "SMTPUTF8";
+            yield return "DSN";
 
             if (context.Pipe.IsSecure == false && context.EndpointDefinition.CertificateFactory != null)
             {

--- a/src/SmtpServer/Protocol/IParameterizedSmtpCommandFactory.cs
+++ b/src/SmtpServer/Protocol/IParameterizedSmtpCommandFactory.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using SmtpServer.Mail;
+
+namespace SmtpServer.Protocol
+{
+    /// <summary>
+    /// Optional SMTP command factory interface for commands with ESMTP parameters.
+    /// </summary>
+    public interface IParameterizedSmtpCommandFactory : ISmtpCommandFactory
+    {
+        /// <summary>
+        /// Create a RCPT command.
+        /// </summary>
+        /// <param name="address">The address that the mail is to.</param>
+        /// <param name="parameters">The optional recipient parameters.</param>
+        /// <returns>The RCPT command.</returns>
+        SmtpCommand CreateRcpt(IMailbox address, IReadOnlyDictionary<string, string> parameters);
+    }
+}

--- a/src/SmtpServer/Protocol/RcptCommand.cs
+++ b/src/SmtpServer/Protocol/RcptCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.ComponentModel;
@@ -22,9 +23,20 @@ namespace SmtpServer.Protocol
         /// Constructor.
         /// </summary>
         /// <param name="address">The address.</param>
-        public RcptCommand(IMailbox address) : base(Command)
+        public RcptCommand(IMailbox address)
+            : this(address, new Dictionary<string, string>())
+        {
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="address">The address.</param>
+        /// <param name="parameters">The list of recipient parameters.</param>
+        public RcptCommand(IMailbox address, IReadOnlyDictionary<string, string> parameters) : base(Command)
         {
             Address = address;
+            Parameters = parameters ?? new Dictionary<string, string>();
         }
 
         /// <summary>
@@ -40,10 +52,15 @@ namespace SmtpServer.Protocol
 
             using var container = new DisposableContainer<IMailboxFilter>(mailboxFilter);
 
-            switch (await container.Instance.CanDeliverToAsync(context, Address, context.Transaction.From, cancellationToken).ConfigureAwait(false))
+            var canDeliverTo = container.Instance is IParameterizedMailboxFilter parameterizedMailboxFilter
+                ? parameterizedMailboxFilter.CanDeliverToAsync(context, Address, context.Transaction.From, Parameters, cancellationToken)
+                : container.Instance.CanDeliverToAsync(context, Address, context.Transaction.From, cancellationToken);
+
+            switch (await canDeliverTo.ConfigureAwait(false))
             {
                 case true:
                     context.Transaction.To.Add(Address);
+                    context.Transaction.Recipients.Add(new SmtpMessageRecipient(Address, Parameters));
                     await context.Pipe.Output.WriteReplyAsync(SmtpResponse.Ok, cancellationToken).ConfigureAwait(false);
                     return true;
 
@@ -59,5 +76,10 @@ namespace SmtpServer.Protocol
         /// Gets the address that the mail is to.
         /// </summary>
         public IMailbox Address { get; }
+
+        /// <summary>
+        /// The list of recipient parameters.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Parameters { get; }
     }
 }

--- a/src/SmtpServer/Protocol/SmtpCommandFactory.cs
+++ b/src/SmtpServer/Protocol/SmtpCommandFactory.cs
@@ -7,7 +7,7 @@ namespace SmtpServer.Protocol
     /// <summary>
     /// Smtp Command Factory
     /// </summary>
-    public class SmtpCommandFactory : ISmtpCommandFactory
+    public class SmtpCommandFactory : IParameterizedSmtpCommandFactory
     {
         /// <inheritdoc />
         public virtual SmtpCommand CreateHelo(string domainOrAddress)
@@ -30,7 +30,13 @@ namespace SmtpServer.Protocol
         /// <inheritdoc />
         public virtual SmtpCommand CreateRcpt(IMailbox address)
         {
-            return new RcptCommand(address);
+            return CreateRcpt(address, new Dictionary<string, string>());
+        }
+
+        /// <inheritdoc />
+        public virtual SmtpCommand CreateRcpt(IMailbox address, IReadOnlyDictionary<string, string> parameters)
+        {
+            return new RcptCommand(address, parameters);
         }
 
         /// <inheritdoc />

--- a/src/SmtpServer/Protocol/SmtpParser.cs
+++ b/src/SmtpServer/Protocol/SmtpParser.cs
@@ -313,9 +313,16 @@ namespace SmtpServer.Protocol
                 return false;
             }
 
-            // TODO: support optional service extension parameters here
+            reader.Skip(TokenKind.Space);
 
-            command = _smtpCommandFactory.CreateRcpt(mailbox);
+            if (reader.TryMake(TryMakeMailParameters, out IReadOnlyDictionary<string, string> parameters) == false)
+            {
+                parameters = new Dictionary<string, string>();
+            }
+
+            command = _smtpCommandFactory is IParameterizedSmtpCommandFactory parameterizedSmtpCommandFactory
+                ? parameterizedSmtpCommandFactory.CreateRcpt(mailbox, parameters)
+                : _smtpCommandFactory.CreateRcpt(mailbox);
             return true;
         }
 

--- a/src/SmtpServer/SmtpMessageRecipient.cs
+++ b/src/SmtpServer/SmtpMessageRecipient.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using SmtpServer.Mail;
+
+namespace SmtpServer
+{
+    sealed class SmtpMessageRecipient : IMessageRecipient
+    {
+        public SmtpMessageRecipient(IMailbox address, IReadOnlyDictionary<string, string> parameters)
+        {
+            Address = address;
+            Parameters = parameters ?? new Dictionary<string, string>();
+        }
+
+        public IMailbox Address { get; }
+
+        public IReadOnlyDictionary<string, string> Parameters { get; }
+    }
+}

--- a/src/SmtpServer/SmtpMessageTransaction.cs
+++ b/src/SmtpServer/SmtpMessageTransaction.cs
@@ -7,7 +7,7 @@ namespace SmtpServer
     /// <summary>
     /// Smtp Message Transaction
     /// </summary>
-    internal sealed class SmtpMessageTransaction : IMessageTransaction
+    internal sealed class SmtpMessageTransaction : IMessageTransaction, IParameterizedMessageTransaction
     {
         /// <summary>
         /// Reset the current transaction.
@@ -16,6 +16,7 @@ namespace SmtpServer
         {
             From = null;
             To = new Collection<IMailbox>();
+            Recipients = new Collection<IMessageRecipient>();
             Parameters = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
         }
 
@@ -24,6 +25,12 @@ namespace SmtpServer
 
         /// <inheritdoc />
         public IList<IMailbox> To { get; set; } = new Collection<IMailbox>();
+
+        /// <inheritdoc />
+        public Collection<IMessageRecipient> Recipients { get; private set; } = new Collection<IMessageRecipient>();
+
+        /// <inheritdoc />
+        IReadOnlyList<IMessageRecipient> IParameterizedMessageTransaction.Recipients => Recipients;
 
         /// <inheritdoc />
         public IReadOnlyDictionary<string, string> Parameters { get; set; } = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());

--- a/src/SmtpServer/Storage/CompositeMailboxFilter.cs
+++ b/src/SmtpServer/Storage/CompositeMailboxFilter.cs
@@ -1,11 +1,12 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.Mail;
 
 namespace SmtpServer.Storage
 {
-    internal sealed class CompositeMailboxFilter : IMailboxFilter
+    internal sealed class CompositeMailboxFilter : IParameterizedMailboxFilter
     {
         readonly IMailboxFilter[] _filters;
 
@@ -56,12 +57,26 @@ namespace SmtpServer.Storage
             IMailbox @from,
             CancellationToken cancellationToken = default)
         {
+            return await CanDeliverToAsync(context, to, @from, new Dictionary<string, string>(), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> CanDeliverToAsync(
+            ISessionContext context,
+            IMailbox to,
+            IMailbox @from,
+            IReadOnlyDictionary<string, string> parameters,
+            CancellationToken cancellationToken = default)
+        {
             if (_filters == null || _filters.Any() == false)
             {
                 return true;
             }
 
-            var results = await Task.WhenAll(_filters.Select(f => f.CanDeliverToAsync(context, to, @from, cancellationToken))).ConfigureAwait(false);
+            var results = await Task.WhenAll(_filters.Select(f =>
+                f is IParameterizedMailboxFilter parameterizedMailboxFilter
+                    ? parameterizedMailboxFilter.CanDeliverToAsync(context, to, @from, parameters, cancellationToken)
+                    : f.CanDeliverToAsync(context, to, @from, cancellationToken))).ConfigureAwait(false);
 
             return results.All(r => r == true);
         }

--- a/src/SmtpServer/Storage/IParameterizedMailboxFilter.cs
+++ b/src/SmtpServer/Storage/IParameterizedMailboxFilter.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using SmtpServer.Mail;
+
+namespace SmtpServer.Storage
+{
+    /// <summary>
+    /// Optional mailbox filter interface for recipient parameters supplied on the RCPT command.
+    /// </summary>
+    public interface IParameterizedMailboxFilter : IMailboxFilter
+    {
+        /// <summary>
+        /// Returns a value indicating whether the given mailbox can be accepted as a recipient to the given sender.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <param name="to">The mailbox to test.</param>
+        /// <param name="from">The sender's mailbox.</param>
+        /// <param name="parameters">The recipient parameters supplied on the RCPT command.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Returns true if the mailbox can be delivered to, false if not.</returns>
+        Task<bool> CanDeliverToAsync(
+            ISessionContext context,
+            IMailbox to,
+            IMailbox from,
+            IReadOnlyDictionary<string, string> parameters,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/SmtpServer/Storage/MailboxFilter.cs
+++ b/src/SmtpServer/Storage/MailboxFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SmtpServer.Mail;
 
@@ -7,7 +8,7 @@ namespace SmtpServer.Storage
     /// <summary>
     /// Mailbox Filter
     /// </summary>
-    public abstract class MailboxFilter : IMailboxFilter
+    public abstract class MailboxFilter : IParameterizedMailboxFilter
     {
         /// <summary>
         /// Default Mailbox Filter
@@ -32,6 +33,17 @@ namespace SmtpServer.Storage
             CancellationToken cancellationToken)
         {
             return Task.FromResult(true);
+        }
+
+        /// <inheritdoc />
+        public virtual Task<bool> CanDeliverToAsync(
+            ISessionContext context,
+            IMailbox to,
+            IMailbox @from,
+            IReadOnlyDictionary<string, string> parameters,
+            CancellationToken cancellationToken)
+        {
+            return CanDeliverToAsync(context, to, @from, cancellationToken);
         }
 
         sealed class DefaultMailboxFilter : MailboxFilter { }

--- a/src/SmtpServer/Tracing/TracingSmtpCommandVisitor.cs
+++ b/src/SmtpServer/Tracing/TracingSmtpCommandVisitor.cs
@@ -107,7 +107,9 @@ namespace SmtpServer.Tracing
         /// <param name="command">The command that is being visited.</param>
         protected override void Visit(RcptCommand command)
         {
-            _output.WriteLine("RCPT: Address={0}", command.Address.AsAddress());
+            _output.WriteLine("RCPT: Address={0} Parameters={1}",
+                command.Address.AsAddress(),
+                string.Join(",", command.Parameters.Select(kvp => $"{kvp.Key}={kvp.Value}")));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Parse and preserve DSN-related MAIL parameters such as `RET` and `ENVID`.
- Parse and preserve RCPT parameters such as `NOTIFY` and `ORCPT`.
- Expose accepted recipients and their RCPT parameters through optional transaction interfaces and `GetRecipients()`.
- Add an optional parameter-aware mailbox filter interface for RCPT-time filtering.
- Advertise `DSN` in EHLO and document the implementation limitation that applications remain responsible for generating delivery status notifications.
- Add parser and raw SMTP integration coverage for DSN envelope parameters.

## Verification
- `DOTNET_ROLL_FORWARD=Major dotnet test src/SmtpServer.Tests/SmtpServer.Tests.csproj --no-restore`
  - Passed: 120, Skipped: 1
  - Existing warnings observed: MailKit NU1902 advisory, existing `AuthCommand` XML doc warning on upstream master, existing xUnit analyzer warnings.
